### PR TITLE
Add optional OpenAI server and client support

### DIFF
--- a/ComfyNodes/__init__.py
+++ b/ComfyNodes/__init__.py
@@ -1,0 +1,15 @@
+import importlib
+
+VisionLLMQuery = importlib.import_module('vllm_query').VisionLLMQuery
+ConditionalSaveImage = importlib.import_module('conditional_save_image').ConditionalSaveImage
+
+NODE_CLASS_MAPPINGS = {
+    "VisionLLMQuery": VisionLLMQuery,
+    "ConditionalSaveImage": ConditionalSaveImage,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "VisionLLMQuery": "Vision LLM Query",
+    "ConditionalSaveImage": "Conditional Save Image",
+}
+

--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ This setup **first compares two images for similarity**, then **generates a Stab
 - **Recreating an image in a different medium**  
 - **Refining AI-generated art iteratively**  
 
+ 
+### **Optional ONNX OpenAI Server**
+
+An example OpenAI compatible server is located at `extras/onnx_openai_server.py`. It exposes a `/v1/chat/completions` endpoint using a local ONNX model. Run it if you want a self-hosted API:
+
+```bash
+python extras/onnx_openai_server.py
+```
+
+Provide the `api_endpoint` and optional `api_key` inputs to `VisionLLMQuery` to query any OpenAI compatible endpoint (including this server or Ollama).
+
 ---
 
 ## **🛠️ Configuration**  

--- a/extras/onnx_openai_server.py
+++ b/extras/onnx_openai_server.py
@@ -1,0 +1,58 @@
+"""Simple OpenAI compatible server using an ONNX model."""
+import os
+import base64
+from typing import List, Dict, Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+import uvicorn
+
+try:
+    import onnxruntime as ort
+except Exception:  # pragma: no cover - optional dependency
+    ort = None
+
+app = FastAPI()
+
+session = None
+
+
+def load_model(path: str) -> None:
+    global session
+    if ort is None:
+        raise RuntimeError("onnxruntime is not installed")
+    session = ort.InferenceSession(path)
+
+
+class ChatRequest(BaseModel):
+    model: str
+    messages: List[Dict[str, Any]]
+
+
+@app.post("/v1/chat/completions")
+def chat(req: ChatRequest):
+    if session is None:
+        return {"choices": [{"message": {"role": "assistant", "content": "Model not loaded"}}]}
+    # Extract text from the last message
+    text = " ".join(
+        part.get("text", "") for msg in req.messages for part in msg.get("content", []) if part.get("type") == "text"
+    )
+    # Dummy example: run model expecting length of text as input
+    import numpy as np
+
+    inp = np.array([[len(text)]], dtype=np.float32)
+    out = session.run(None, {session.get_inputs()[0].name: inp})
+    result = str(out[0].flatten()[0])
+    return {"choices": [{"message": {"role": "assistant", "content": result}}]}
+
+
+def main():
+    model_path = os.environ.get("ONNX_MODEL_PATH")
+    if model_path:
+        load_model(model_path)
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "8000")))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,0 +1,22 @@
+import base64
+import json
+import requests
+
+
+def image_bytes_to_data_url(image_bytes: bytes) -> str:
+    """Convert raw image bytes to a base64 data URL."""
+    b64 = base64.b64encode(image_bytes).decode("utf-8")
+    return f"data:image/png;base64,{b64}"
+
+
+def chat_completion(endpoint: str, model: str, messages: list, api_key: str | None = None) -> str:
+    """Send a chat completion request to an OpenAI compatible endpoint."""
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    payload = {"model": model, "messages": messages}
+    response = requests.post(f"{endpoint}/v1/chat/completions", headers=headers, json=payload, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    return data["choices"][0]["message"]["content"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/vllm_query.py
+++ b/vllm_query.py
@@ -20,6 +20,7 @@ from .string_utils import fuzzy_match_bool
 from .util.task_data import TaskData
 from .transformer_worker.transformer_worker import list_cached_vision_models
 from .transformer_worker.helpers import has_model_issues, get_model_issues, strip_warning_prefix
+from .openai_client import chat_completion, image_bytes_to_data_url
 
 LOG_FILE = os.path.join(os.path.dirname(__file__), "logs", "inference_results.csv")
 
@@ -266,6 +267,8 @@ class VisionLLMQuery:
             },
             "optional": {
                 "reference_image": ("IMAGE",),  # Optional reference image
+                "api_endpoint": ("STRING", {"default": ""}),
+                "api_key": ("STRING", {"default": ""}),
             }
         }
 
@@ -302,7 +305,22 @@ class VisionLLMQuery:
         text_query = inputs.get("text_query", "Describe the image.")
 
         reference_image = inputs.get("reference_image", None)  # Optional!
+        api_endpoint = inputs.get("api_endpoint", "")
+        api_key = inputs.get("api_key", "")
         max_retries = 3
+
+        if api_endpoint:
+            # Use remote OpenAI-compatible API
+            image_bytes = image_to_bytes(image)
+            content = []
+            if reference_image is not None:
+                content.append({"type": "image_url", "image_url": {"url": image_bytes_to_data_url(image_to_bytes(reference_image))}})
+            content.append({"type": "image_url", "image_url": {"url": image_bytes_to_data_url(image_bytes)}})
+            content.append({"type": "text", "text": text_query})
+            messages = [{"role": "user", "content": content}]
+            response_text = chat_completion(api_endpoint, model_name, messages, api_key if api_key else None)
+            bool_output = fuzzy_match_bool(response_text)
+            return response_text, bool_output, int(bool_output)
 
         if not hasattr(self, "worker"):  # Create worker if not already running
             logging.debug("🚀 Starting persistent inference worker...")


### PR DESCRIPTION
## Summary
- implement OpenAI-compatible request helper
- allow VisionLLMQuery to call remote endpoints when `api_endpoint` is set
- add optional ONNX server example under `extras`
- document usage of optional server
- add minimal requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687480b48fac8331a4db251ec87d0027