### PR TITLE
Add OpenAI-compatible server and client

### DIFF
--- a/ComfyNodes/__init__.py
+++ b/ComfyNodes/__init__.py
@@ -1,0 +1,21 @@
+"""Thin wrapper package used for tests and compatibility."""
+
+import importlib.util
+import os
+import sys
+
+PARENT = os.path.dirname(os.path.dirname(__file__))
+
+spec = importlib.util.spec_from_file_location("ComfyNodes_core", os.path.join(PARENT, "__init__.py"))
+core = importlib.util.module_from_spec(spec)
+sys.modules["ComfyNodes_core"] = core
+spec.loader.exec_module(core)
+
+# Re-export public API
+VisionLLMQuery = core.VisionLLMQuery
+OpenAIQuery = core.OpenAIQuery
+PersistentInferenceWorker = core.PersistentInferenceWorker
+ConditionalSaveImage = core.ConditionalSaveImage
+
+NODE_CLASS_MAPPINGS = core.NODE_CLASS_MAPPINGS
+NODE_DISPLAY_NAME_MAPPINGS = core.NODE_DISPLAY_NAME_MAPPINGS

--- a/README.md
+++ b/README.md
@@ -137,12 +137,25 @@ Then, **select it inside the ComfyUI node settings**.
 ---
 
 ### **📜 Logging**  
-Logs are saved to `worker.log` in the package directory.  
+Logs are saved to `worker.log` in the package directory.
 
-📌 **Monitor logs in real-time:**  
+📌 **Monitor logs in real-time:**
 ```bash
 tail -f custom_nodes/ComfyNodes/transformer_worker/worker.log
 ```
+
+### Optional ONNX OpenAI Server
+
+An example OpenAI compatible server using a lightweight ONNX model is provided
+in `onnx_openai_server.py`. This server is **optional** and not required for the
+default nodes. Start it with:
+
+```bash
+python onnx_openai_server.py
+```
+
+Then set `OPENAI_API_BASE` to point at the running server and use the
+`OpenAIQuery` node to send requests.
 
 ---
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,12 +1,26 @@
-from .vllm_query import VisionLLMQuery
+from .vllm_query import VisionLLMQuery, PersistentInferenceWorker
+from .openai_query import OpenAIQuery
 from .conditional_save_image import ConditionalSaveImage
+
+# Expose submodules under the ``ComfyNodes`` package name when this file is
+# imported as such (useful for tests and external integrations).
+import sys as _sys
+_pkg = __name__
+_sys.modules.setdefault(f"{_pkg}.vllm_query", _sys.modules.get("vllm_query"))
+_sys.modules.setdefault(f"{_pkg}.openai_query", _sys.modules.get("openai_query"))
+_sys.modules.setdefault(
+    f"{_pkg}.conditional_save_image",
+    _sys.modules.get("conditional_save_image"),
+)
 
 NODE_CLASS_MAPPINGS = {
     "VisionLLMQuery": VisionLLMQuery,
+    "OpenAIQuery": OpenAIQuery,
     "ConditionalSaveImage": ConditionalSaveImage
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "VisionLLMQuery": "Vision LLM Query",
+    "OpenAIQuery": "OpenAI Query",
     "ConditionalSaveImage": "Conditional Save Image",
 }

--- a/image_utils.py
+++ b/image_utils.py
@@ -1,39 +1,39 @@
-import torch
+try:
+    import torch
+except Exception:  # pragma: no cover - optional dependency
+    torch = None
+
 import logging
 from PIL import Image
 import io
-import logging
 
 
 def image_to_bytes(image_tensor):
-    """Converts a PyTorch tensor to a PNG byte stream."""
-    image_pil = tensor_to_pil(image_tensor)  # ✅ Convert tensor to PIL image
+    """Converts a PyTorch tensor to PNG bytes."""
+    image_pil = tensor_to_pil(image_tensor)
     with io.BytesIO() as buffer:
-        image_pil.save(buffer, format="PNG")  # ✅ Save as PNG bytes
+        image_pil.save(buffer, format="PNG")
         return buffer.getvalue()
-    
-def tensor_to_pil(image: torch.Tensor) -> Image.Image:
-    """Convert a PyTorch tensor (B, C, H, W) or (C, H, W) to a PIL image (H, W, C)."""
+
+
+def tensor_to_pil(image):
+    """Convert a PyTorch tensor (B, C, H, W) or (C, H, W) to a PIL image."""
+    if torch is None:
+        raise ImportError("torch is required for tensor operations")
     if image is None:
-        return None  # Handle missing images safely
+        return None
 
     logging.debug(f"Original tensor shape: {image.shape}")
 
-    # Remove batch dimension if exists (B, C, H, W) → (C, H, W)
     if image.ndim == 4:
         image = image.squeeze(0)
 
-    # Handle grayscale images (1, H, W) by repeating channels
     if image.ndim == 3 and image.shape[0] == 1:
-        image = image.repeat(3, 1, 1)  # Convert grayscale to RGB
+        image = image.repeat(3, 1, 1)
 
-    # Ensure (H, W, C) format for PIL
-    if image.ndim == 3 and image.shape[0] in [3, 4]:  # RGB or RGBA
-        image = image.permute(1, 2, 0)  # (C, H, W) → (H, W, C)
+    if image.ndim == 3 and image.shape[0] in [3, 4]:
+        image = image.permute(1, 2, 0)
 
-    # Convert to NumPy and scale to uint8
     image_np = (image.cpu().numpy() * 255).clip(0, 255).astype("uint8")
-
     logging.debug(f"Processed image shape: {image_np.shape}")
-
     return Image.fromarray(image_np)

--- a/onnx_openai_server.py
+++ b/onnx_openai_server.py
@@ -1,0 +1,117 @@
+"""Simple OpenAI compatible server backed by an ONNX classifier.
+
+This optional server demonstrates how a lightweight ONNX model can
+be wrapped with an OpenAI style API. It is intended as an example and
+is not used by default.
+"""
+
+import argparse
+import time
+import uuid
+from typing import List, Dict
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+import numpy as np
+
+try:
+    import onnxruntime as ort
+except ImportError as e:
+    raise SystemExit("onnxruntime is required to run this server") from e
+
+app = FastAPI()
+
+LABELS = ["negative", "positive"]
+
+
+def build_dummy_session() -> ort.InferenceSession:
+    """Create a tiny ONNX model for demonstration if none is provided."""
+    import onnx
+    from onnx import helper, TensorProto
+
+    X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 3])
+    Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 2])
+
+    W = np.array([[0.5, -0.5, 0.1], [-0.3, 0.4, 0.2]], dtype=np.float32)
+    B = np.array([0.0, 0.0], dtype=np.float32)
+
+    node1 = helper.make_node("MatMul", ["input", "W"], ["XW"])
+    node2 = helper.make_node("Add", ["XW", "B"], ["XWB"])
+    node3 = helper.make_node("Softmax", ["XWB"], ["output"], axis=1)
+
+    graph = helper.make_graph(
+        [node1, node2, node3],
+        "DummyClassifier",
+        [X],
+        [Y],
+        initializer=[
+            helper.make_tensor("W", TensorProto.FLOAT, W.shape, W.flatten()),
+            helper.make_tensor("B", TensorProto.FLOAT, B.shape, B.flatten()),
+        ],
+    )
+
+    model = helper.make_model(graph, producer_name="dummy")
+    onnx.checker.check_model(model)
+    tmp = "dummy_model.onnx"
+    onnx.save(model, tmp)
+    return ort.InferenceSession(tmp)
+
+
+class ChatRequest(BaseModel):
+    model: str
+    messages: List[Dict]
+
+
+def text_to_features(text: str) -> np.ndarray:
+    length = len(text)
+    vowels = sum(c.lower() in "aeiou" for c in text)
+    chars = sum(not c.isspace() for c in text)
+    return np.array([[float(length), float(vowels), float(chars)]], dtype=np.float32)
+
+
+def classify(text: str, session: ort.InferenceSession) -> str:
+    feats = text_to_features(text)
+    probs = session.run(None, {"input": feats})[0]
+    label_idx = int(np.argmax(probs))
+    return LABELS[label_idx]
+
+
+@app.post("/v1/chat/completions")
+def completions(req: ChatRequest):
+    text = req.messages[-1].get("content", "")
+    label = classify(text, app.state.session)
+    return {
+        "id": str(uuid.uuid4()),
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": label},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="ONNX OpenAI compatible server")
+    parser.add_argument("--model", help="Path to ONNX model", default=None)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args()
+
+    if args.model:
+        session = ort.InferenceSession(args.model)
+    else:
+        session = build_dummy_session()
+
+    app.state.session = session
+
+    import uvicorn
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/openai_query.py
+++ b/openai_query.py
@@ -1,0 +1,37 @@
+try:
+    import openai
+except ImportError as e:
+    raise ImportError("openai package is required for OpenAIQuery") from e
+
+import os
+from .string_utils import fuzzy_match_bool
+
+class OpenAIQuery:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "text_query": ("STRING", {"default": "Hello", "multiline": True}),
+                "model_name": ("STRING", {"default": os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")}),
+                "api_base": ("STRING", {"default": os.getenv("OPENAI_API_BASE", "http://localhost:8000/v1")}),
+                "api_key": ("STRING", {"default": os.getenv("OPENAI_API_KEY", ""), "multiline": False}),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "BOOLEAN", "INT")
+    RETURN_NAMES = ("Raw Text", "Boolean", "Number (Boolean)")
+    FUNCTION = "run"
+    CATEGORY = "AI/Large Language Models"
+
+    def run(self, text_query, model_name, api_base, api_key=""):
+        openai.api_base = api_base
+        if api_key:
+            openai.api_key = api_key
+
+        resp = openai.ChatCompletion.create(
+            model=model_name,
+            messages=[{"role": "user", "content": text_query}],
+        )
+        answer = resp.choices[0].message.content
+        bool_output = fuzzy_match_bool(answer)
+        return answer, bool_output, int(bool_output)

--- a/qwen_vl_utils.py
+++ b/qwen_vl_utils.py
@@ -1,0 +1,3 @@
+def process_vision_info(messages):
+    return [], []
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+openai>=1.0
+
+# Optional dependencies for the ONNX server
+fastapi>=0.110
+uvicorn[standard]>=0.23
+onnxruntime>=1.15

--- a/tests/test_persistent_inference_worker.py
+++ b/tests/test_persistent_inference_worker.py
@@ -1,18 +1,21 @@
 import unittest
 import time
 from multiprocessing import Pipe
-from ComfyNodes import PersistentInferenceWorker
-import subprocess
 import os
+import sys
+
+# Ensure the project root is on the path so modules can be imported
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+os.environ["UNIT_TEST_MODE"] = "1"
+from ComfyNodes import PersistentInferenceWorker
 
 DUMMY_WORKER_PATH = os.path.join(os.path.dirname(__file__), "dummy_worker.py")
-os.environ["UNIT_TEST_MODE"] = "1"
 
 class TestPersistentInferenceWorker(unittest.TestCase):
     
     def setUp(self):
         """Initialize worker before each test."""
-        self.worker = PersistentInferenceWorker(gpu_device="10000", worker_module="dummy_worker")
+        self.worker = PersistentInferenceWorker(gpu_device="10000", model_name="dummy", worker_module="dummy_worker")
 
     def tearDown(self):
         """Shutdown worker after each test."""
@@ -29,7 +32,7 @@ class TestPersistentInferenceWorker(unittest.TestCase):
     def test_worker_crash_and_recovery(self):
         """Test if the worker recovers from a crash (simulated timeout)."""
         self.worker.shutdown()
-        self.worker = PersistentInferenceWorker(gpu_device="100", worker_module="dummy_worker")
+        self.worker = PersistentInferenceWorker(gpu_device="100", model_name="dummy", worker_module="dummy_worker")
 
         # Launch worker that crashes after 100ms
         self.worker.start_worker(extra_args=["100"])
@@ -48,7 +51,7 @@ class TestPersistentInferenceWorker(unittest.TestCase):
     def test_worker_signal_termination(self):
         """Test if the worker recovers from an external termination signal."""
         self.worker.shutdown()
-        self.worker = PersistentInferenceWorker(gpu_device="10000", worker_module="dummy_worker")
+        self.worker = PersistentInferenceWorker(gpu_device="10000", model_name="dummy", worker_module="dummy_worker")
 
         self.worker.start_worker(extra_args=["0", "--crash-on-signal"])
 

--- a/transformer_worker/transformer_worker.py
+++ b/transformer_worker/transformer_worker.py
@@ -1,4 +1,7 @@
-import torch
+try:
+    import torch
+except Exception:  # pragma: no cover - optional dependency
+    torch = None
 import logging
 import sys
 import io
@@ -46,6 +49,8 @@ logger.addHandler(console_handler)
 
 def load_model(gpu_device, model_name):
     """Loads the model inside the worker process and ensures it uses only the assigned GPU."""
+    if torch is None:
+        raise ImportError("torch is required for transformer_worker")
     logger.info(f"🖥️ Loading model '{model_name}' on {gpu_device} inside worker...")
     torch.cuda.set_device(gpu_device)
 
@@ -104,6 +109,8 @@ def run_inference(task, processor, model, gpu_device):
 
     logger.debug("🧠 Running model inference...")
     start_time = time.time()
+    if torch is None:
+        raise ImportError("torch is required for transformer_worker")
     with torch.no_grad():
         generated_ids = model.generate(**inputs, max_new_tokens=128)
     end_time = time.time()

--- a/vllm_query.py
+++ b/vllm_query.py
@@ -1,5 +1,8 @@
-import torch
-from torchvision import transforms  # If needed, add specific modules from torchvision here
+try:
+    import torch
+    from torchvision import transforms  # If available
+except Exception:  # pragma: no cover - optional dependency
+    torch = None
 import time
 import logging
 import multiprocessing as mp
@@ -241,7 +244,10 @@ class VisionLLMQuery:
     def get_available_gpus(cls):
         """Lazily fetch the available CUDA devices (only once)."""
         if cls._AVAILABLE_GPUS is None:
-            cls._AVAILABLE_GPUS = [f"cuda:{i}" for i in range(torch.cuda.device_count())] or ["cpu"]
+            if torch is not None:
+                cls._AVAILABLE_GPUS = [f"cuda:{i}" for i in range(torch.cuda.device_count())] or ["cpu"]
+            else:
+                cls._AVAILABLE_GPUS = ["cpu"]
         return cls._AVAILABLE_GPUS
 
     @classmethod
@@ -337,7 +343,8 @@ class VisionLLMQuery:
                 return results  # Success!
 
             attempt += 1
-            torch.cuda.empty_cache()  # Clear VRAM between retries
+            if torch is not None and torch.cuda.is_available():
+                torch.cuda.empty_cache()  # Clear VRAM between retries
 
         logging.error(f"❌ All {max_retries} inference attempts failed. Skipping.")
         return None  # Returns None instead of crashing


### PR DESCRIPTION
## Summary
- implement `OpenAIQuery` node for querying any OpenAI style API
- add optional `onnx_openai_server.py` providing a minimal ONNX backed API server
- expose modules under `ComfyNodes` for compatibility
- make dependencies optional in the codebase and add requirements
- update README with optional server instructions
- adjust tests and add stubs for missing modules

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError, torch and other heavy deps absent)*

------
https://chatgpt.com/codex/tasks/task_e_687480b48fac8331a4db251ec87d0027