### PR TITLE
Enable two-image queries via HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 🚀 **ComfyAI** is an advanced **LLM-powered query node** for **ComfyUI**, enabling both **text-based and vision-based inference** using multimodal models like **Qwen-VL** and **Llava**.  
 
-This project exposes a lightweight HTTP API for text or vision models and can use any OpenAI-compatible endpoint, including the optional ONNX server.
+This project exposes a lightweight HTTP API. The ComfyUI node simply calls
+an **OpenAI-compatible endpoint** so the actual LLM can run on a remote
+server (for example the included ONNX server or any OpenAI-like service).
 
 ---
 
@@ -57,14 +59,17 @@ pip install -e .[llm]
 
 1. **Start ComfyUI** (ensure it’s installed and running).  
 2. **Load the custom node from ComfyAI**.  
-3. **Connect image/text inputs** and send queries.  
+3. **Connect image/text inputs** and send queries.
 4. **Requests are sent to your configured API endpoint**.
+   The node itself simply performs an HTTP request to an
+   **OpenAI-compatible endpoint** so the heavy LLM can run anywhere.
 
 ---
 
-### **📌 Use Case 1 - Single Image → Text Output**  
+### **📌 Use Case 1 - Single Image → Text Output**
 
-To **describe an image**, pass it as `sample`. The `reference` input is only used for comparisons.  
+To **describe an image**, pass it to the `image` input. The optional
+`reference_image` input is only used when doing comparisons.
 
 **Example Workflow:**  
 ![Single Image Example](Example01.png)  
@@ -74,9 +79,10 @@ To **describe an image**, pass it as `sample`. The `reference` input is only use
 
 ---
 
-### **📌 Use Case 2 - Comparing Two Images (Boolean Output)**  
+### **📌 Use Case 2 - Comparing Two Images (Boolean Output)**
 
-The **Vision LLM** can compare **two images** and **output a True/False result**.  
+Provide both `image` and `reference_image` to compare them. The
+**Vision LLM** can compare **two images** and **output a True/False result**.
 
 **Example Workflow:**  
 ![Image Comparison Example](Example02.png)  

--- a/onnx_vllm_server.py
+++ b/onnx_vllm_server.py
@@ -15,6 +15,7 @@ app = FastAPI()
 class ChatRequest(BaseModel):
     model: str
     messages: List[Dict[str, Any]]
+    images: List[str] | None = None
     max_tokens: int | None = None
 
 session = None
@@ -50,6 +51,9 @@ async def chat(request: Request):
         raise HTTPException(status_code=400, detail=e.errors())
 
     text = req.messages[-1].get("content", "") if req.messages else ""
+    # Currently we simply ignore the images but validate the input
+    if req.images:
+        _ = len(req.images)
     result = classify(text)
     return {
         "id": "cmpl-001",

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,13 +1,53 @@
 import requests
 
 
-def chat_completion(endpoint: str, model: str, messages, api_key: str | None = None, timeout: int = 30, **kwargs) -> str:
-    """Send a chat completion request to an OpenAI compatible endpoint."""
+import base64
+
+
+def chat_completion(
+    endpoint: str,
+    model: str,
+    messages,
+    api_key: str | None = None,
+    timeout: int = 30,
+    images=None,
+    **kwargs,
+) -> str:
+    """Send a chat completion request to an OpenAI compatible endpoint.
+
+    Parameters
+    ----------
+    endpoint : str
+        Base URL of the API.
+    model : str
+        Model name to query.
+    messages : list
+        Chat message history.
+    api_key : str | None, optional
+        Optional API key.
+    timeout : int, optional
+        Request timeout.
+    images : list[bytes | str] | None, optional
+        Optional list of images to include in the request. ``bytes`` are
+        base64-encoded automatically.
+    """
+
     headers = {"Content-Type": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
+
     payload = {"model": model, "messages": messages}
+
+    if images:
+        encoded = []
+        for img in images:
+            if isinstance(img, bytes):
+                img = base64.b64encode(img).decode("utf-8")
+            encoded.append(img)
+        payload["images"] = encoded
+
     payload.update(kwargs)
+
     url = endpoint.rstrip("/") + "/v1/chat/completions"
     response = requests.post(url, headers=headers, json=payload, timeout=timeout)
     response.raise_for_status()

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -26,3 +26,24 @@ def test_chat_completion(monkeypatch):
     assert called['json']['max_tokens'] == 5
     assert called['json']['temperature'] == 0.7
     assert result == "ok"
+
+
+def test_chat_completion_with_images(monkeypatch):
+    called = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        called['json'] = json
+        response = SimpleNamespace()
+        response.json = lambda: {"choices": [{"message": {"content": "ok"}}]}
+        response.raise_for_status = lambda: None
+        return response
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    openai_client.chat_completion(
+        "http://host",
+        "gpt",
+        [ {"role": "user", "content": "hi"} ],
+        images=[b"a", b"b"],
+    )
+
+    assert called['json']['images'] == ["YQ==", "Yg=="]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,6 +21,19 @@ def test_chat_endpoint_success(monkeypatch):
     assert "id" in data
 
 
+def test_chat_endpoint_with_images(monkeypatch):
+    client = _client(monkeypatch)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "images": ["img1", "img2"],
+        },
+    )
+    assert resp.status_code == 200
+
+
 def test_chat_endpoint_missing_messages(monkeypatch):
     client = _client(monkeypatch)
     resp = client.post("/v1/chat/completions", json={"model": "x"})

--- a/vllm_query.py
+++ b/vllm_query.py
@@ -1,6 +1,8 @@
 import logging
+import base64
 from string_utils import fuzzy_match_bool
 from openai_client import chat_completion
+from image_utils import image_to_bytes
 
 class VisionLLMQuery:
     @classmethod
@@ -31,6 +33,20 @@ class VisionLLMQuery:
         api_key = inputs.get("api_key", "") or None
         text_query = inputs.get("text_query", "")
         messages = [{"role": "user", "content": text_query}]
-        result = chat_completion(api_endpoint, api_model, messages, api_key=api_key)
+
+        images = []
+        for key in ("image", "reference_image"):
+            img_tensor = inputs.get(key)
+            if img_tensor is not None:
+                byte_data = image_to_bytes(img_tensor)
+                images.append(base64.b64encode(byte_data).decode("utf-8"))
+
+        result = chat_completion(
+            api_endpoint,
+            api_model,
+            messages,
+            api_key=api_key,
+            images=images or None,
+        )
         bool_output = fuzzy_match_bool(result)
         return result, bool_output, int(bool_output)


### PR DESCRIPTION
## Summary
- update docs to clarify decoupled HTTP API
- document `image`/`reference_image` inputs for comparisons
- add optional image list to `openai_client.chat_completion`
- convert node inputs to base64 and pass through API
- allow server to accept image lists
- test image handling in server and client

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a27fc11c833188c4e0279962b868