### PR TITLE
Add two-image support for API and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 🚀 **ComfyAI** is an advanced **LLM-powered query node** for **ComfyUI**, enabling both **text-based and vision-based inference** using multimodal models like **Qwen-VL** and **Llava**.  
 
-This project exposes a lightweight HTTP API for text or vision models and can use any OpenAI-compatible endpoint, including the optional ONNX server.
+This project exposes a lightweight HTTP API for text or vision models. The ComfyUI node is completely decoupled from the LLM and communicates with **any OpenAI-compatible HTTP endpoint** – including the optional ONNX server or remote services like OpenAI and Ollama.
 
 ---
 
@@ -10,8 +10,8 @@ This project exposes a lightweight HTTP API for text or vision models and can us
 
 - ✅ **Text & Vision-Based LLM Inference** – Process **both images and text** in ComfyUI.  
 - ✅ **Multimodal Model Support** – Works with **Qwen-VL**, **Llava**, and more.  
-- ✅ **Stable & Resilient** – Offloads heavy inference to an optional external server.
-- ✅ **Optimized Image Handling** – Minimizes memory usage with **controlled tokenization**.  
+- ✅ **Stable & Resilient** – The node talks to your chosen HTTP endpoint so heavy inference can run remotely.
+- ✅ **Optimized Image Handling** – Supports **two-image comparisons** and minimizes memory usage.
 
 ---
 

--- a/image_utils.py
+++ b/image_utils.py
@@ -5,7 +5,7 @@ except Exception:  # pragma: no cover - optional
 import logging
 from PIL import Image
 import io
-import logging
+import base64
 
 
 def image_to_bytes(image_tensor):
@@ -42,3 +42,9 @@ def tensor_to_pil(image):
     logging.debug(f"Processed image shape: {image_np.shape}")
 
     return Image.fromarray(image_np)
+
+
+def image_to_base64(image_tensor) -> str:
+    """Convert a tensor to a base64 encoded PNG string."""
+    data = image_to_bytes(image_tensor)
+    return base64.b64encode(data).decode("utf-8")

--- a/onnx_vllm_server.py
+++ b/onnx_vllm_server.py
@@ -37,6 +37,21 @@ def classify(text: str) -> str:
     return str(outputs[0])
 
 
+def extract_text(content: Any) -> str:
+    """Extract text segments from an OpenAI-style message content."""
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                parts.append(item.get("text", ""))
+            elif isinstance(item, str):
+                parts.append(item)
+        return " ".join(parts)
+    elif isinstance(content, str):
+        return content
+    return ""
+
+
 @app.post("/v1/chat/completions")
 async def chat(request: Request):
     try:
@@ -49,7 +64,8 @@ async def chat(request: Request):
     except ValidationError as e:
         raise HTTPException(status_code=400, detail=e.errors())
 
-    text = req.messages[-1].get("content", "") if req.messages else ""
+    content = req.messages[-1].get("content", "") if req.messages else ""
+    text = extract_text(content)
     result = classify(text)
     return {
         "id": "cmpl-001",

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,32 @@
+import os
+os.environ['UNIT_TEST_MODE'] = '1'
+
+import openai_client
+import image_utils
+from vllm_query import VisionLLMQuery
+
+
+def test_node_two_images(monkeypatch):
+    called = {}
+    def fake_chat(endpoint, model, messages, api_key=None, timeout=30):
+        called['messages'] = messages
+        return 'ok'
+    monkeypatch.setattr(openai_client, 'chat_completion', fake_chat)
+    monkeypatch.setattr(image_utils, 'image_to_base64', lambda x: 'imgdata')
+    import vllm_query
+    monkeypatch.setattr(vllm_query, 'image_to_base64', lambda x: 'imgdata')
+    monkeypatch.setattr(vllm_query, 'chat_completion', fake_chat)
+
+    node = VisionLLMQuery()
+    result = node.run(
+        api_endpoint='http://x',
+        api_model='gpt',
+        text_query='hi',
+        image=object(),
+        reference_image=object()
+    )
+    assert result[0] == 'ok'
+    content = called['messages'][0]['content']
+    assert len(content) == 3
+    assert content[1]['type'] == 'image_url'
+    assert content[2]['type'] == 'image_url'

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,9 +3,13 @@ from fastapi.testclient import TestClient
 import onnx_vllm_server
 
 
-def _client(monkeypatch):
-    # ensure classify returns predictable output
-    monkeypatch.setattr(onnx_vllm_server, "classify", lambda text: "positive")
+def _client(monkeypatch, capture=None):
+    def _fake(text):
+        if capture is not None:
+            capture.append(text)
+        return "positive"
+
+    monkeypatch.setattr(onnx_vllm_server, "classify", _fake)
     return TestClient(onnx_vllm_server.app)
 
 
@@ -35,3 +39,26 @@ def test_chat_endpoint_invalid_json(monkeypatch):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 400
+
+
+def test_chat_endpoint_with_images(monkeypatch):
+    captured = []
+    client = _client(monkeypatch, capture=captured)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "good"},
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,a"}},
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,b"}},
+                    ],
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200
+    assert captured[0] == "good"

--- a/vllm_query.py
+++ b/vllm_query.py
@@ -1,6 +1,7 @@
 import logging
 from string_utils import fuzzy_match_bool
 from openai_client import chat_completion
+from image_utils import image_to_base64
 
 class VisionLLMQuery:
     @classmethod
@@ -30,7 +31,21 @@ class VisionLLMQuery:
         api_model = inputs.get("api_model", "gpt-3.5-turbo")
         api_key = inputs.get("api_key", "") or None
         text_query = inputs.get("text_query", "")
-        messages = [{"role": "user", "content": text_query}]
+        image = inputs.get("image")
+        ref_image = inputs.get("reference_image")
+
+        if image is not None or ref_image is not None:
+            content = [{"type": "text", "text": text_query}]
+            if image is not None:
+                b64 = image_to_base64(image)
+                content.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}})
+            if ref_image is not None:
+                b64 = image_to_base64(ref_image)
+                content.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}})
+            messages = [{"role": "user", "content": content}]
+        else:
+            messages = [{"role": "user", "content": text_query}]
+
         result = chat_completion(api_endpoint, api_model, messages, api_key=api_key)
         bool_output = fuzzy_match_bool(result)
         return result, bool_output, int(bool_output)


### PR DESCRIPTION
## Summary
- support base64 images in client node
- allow optional two-image input for comparison
- server extracts text from multi-part messages
- document decoupling from LLM and two-image handling
- add tests for comparing two images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a27fc11c833188c4e0279962b868