### PR TITLE
Add OpenAI endpoint image comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # **ComfyAI – LLM-Powered Vision & Text Query Node for ComfyUI**  
 
-🚀 **ComfyAI** is an advanced **LLM-powered query node** for **ComfyUI**, enabling both **text-based and vision-based inference** using multimodal models like **Qwen-VL** and **Llava**.  
+🚀 **ComfyAI** is an advanced **LLM-powered query node** for **ComfyUI**, enabling both **text-based and vision-based inference** using multimodal models like **Qwen-VL** and **Llava**.
 
-This project exposes a lightweight HTTP API for text or vision models and can use any OpenAI-compatible endpoint, including the optional ONNX server.
+The node is completely decoupled from the LLM. Queries are sent over HTTP to **any OpenAI-compatible endpoint**, including the optional ONNX server or the official OpenAI API.
 
 ---
 
@@ -57,8 +57,8 @@ pip install -e .[llm]
 
 1. **Start ComfyUI** (ensure it’s installed and running).  
 2. **Load the custom node from ComfyAI**.  
-3. **Connect image/text inputs** and send queries.  
-4. **Requests are sent to your configured API endpoint**.
+3. **Connect image/text inputs** (optionally **two images** for comparison) and send queries.
+4. **Requests are sent over HTTP to your configured API endpoint**.
 
 ---
 

--- a/onnx_vllm_server.py
+++ b/onnx_vllm_server.py
@@ -1,5 +1,6 @@
 import os
-from typing import List, Dict, Any
+import base64
+from typing import List, Dict, Any, Tuple
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -19,6 +20,27 @@ class ChatRequest(BaseModel):
 
 session = None
 MODEL_PATH = os.environ.get("ONNX_MODEL_PATH")
+
+
+def _parse_content(content: Any) -> Tuple[str, list[bytes]]:
+    """Extract text and image bytes from message content."""
+    text = ""
+    images: list[bytes] = []
+    if isinstance(content, list):
+        for part in content:
+            if part.get("type") == "text":
+                text += part.get("text", "")
+            elif part.get("type") == "image_url":
+                url = part.get("image_url", {}).get("url", "")
+                if url.startswith("data:image"):
+                    try:
+                        encoded = url.split(",", 1)[1]
+                        images.append(base64.b64decode(encoded))
+                    except Exception:
+                        pass
+    else:
+        text = str(content or "")
+    return text, images
 
 
 def load_session():
@@ -49,7 +71,9 @@ async def chat(request: Request):
     except ValidationError as e:
         raise HTTPException(status_code=400, detail=e.errors())
 
-    text = req.messages[-1].get("content", "") if req.messages else ""
+    content = req.messages[-1].get("content", "") if req.messages else ""
+    text, images = _parse_content(content)
+    # images are ignored in this simple example but parsing verifies they exist
     result = classify(text)
     return {
         "id": "cmpl-001",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 import onnx_vllm_server
+import base64
 
 
 def _client(monkeypatch):
@@ -19,6 +20,24 @@ def test_chat_endpoint_success(monkeypatch):
     data = resp.json()
     assert data["choices"][0]["message"]["content"] == "positive"
     assert "id" in data
+
+
+def test_chat_endpoint_two_images(monkeypatch):
+    client = _client(monkeypatch)
+    img1 = base64.b64encode(b"img1").decode()
+    img2 = base64.b64encode(b"img2").decode()
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "hi"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img1}"}},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img2}"}},
+        ],
+    }]
+    resp = client.post("/v1/chat/completions", json={"model": "test", "messages": messages})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["choices"][0]["message"]["content"] == "positive"
 
 
 def test_chat_endpoint_missing_messages(monkeypatch):

--- a/tests/test_vllm_query.py
+++ b/tests/test_vllm_query.py
@@ -1,0 +1,30 @@
+import vllm_query
+
+
+def test_two_image_message(monkeypatch):
+    captured = {}
+
+    def fake_chat(endpoint, model, messages, api_key=None):
+        captured['messages'] = messages
+        return "ok"
+
+    monkeypatch.setattr(vllm_query, "chat_completion", fake_chat)
+    monkeypatch.setattr(vllm_query, "image_to_bytes", lambda img: b"data")
+
+    node = vllm_query.VisionLLMQuery()
+    result = node.run(
+        api_endpoint="http://host",
+        api_model="gpt",
+        api_key="k",
+        text_query="hello",
+        image="img1",
+        reference_image="img2",
+    )
+
+    msgs = captured['messages'][0]['content']
+    assert len(msgs) == 3
+    assert msgs[1]['type'] == 'image_url'
+    assert msgs[2]['type'] == 'image_url'
+    # ensure function returns expected tuple
+    assert result[0] == "ok"
+

--- a/vllm_query.py
+++ b/vllm_query.py
@@ -1,6 +1,8 @@
 import logging
+import base64
 from string_utils import fuzzy_match_bool
 from openai_client import chat_completion
+from image_utils import image_to_bytes
 
 class VisionLLMQuery:
     @classmethod
@@ -30,7 +32,21 @@ class VisionLLMQuery:
         api_model = inputs.get("api_model", "gpt-3.5-turbo")
         api_key = inputs.get("api_key", "") or None
         text_query = inputs.get("text_query", "")
-        messages = [{"role": "user", "content": text_query}]
+        image = inputs.get("image")
+        ref_image = inputs.get("reference_image")
+
+        content_parts = [{"type": "text", "text": text_query}]
+        if image is not None:
+            img_bytes = image_to_bytes(image)
+            b64 = base64.b64encode(img_bytes).decode()
+            content_parts.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}})
+        if ref_image is not None:
+            img_bytes = image_to_bytes(ref_image)
+            b64 = base64.b64encode(img_bytes).decode()
+            content_parts.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}})
+
+        messages = [{"role": "user", "content": content_parts}]
+
         result = chat_completion(api_endpoint, api_model, messages, api_key=api_key)
         bool_output = fuzzy_match_bool(result)
         return result, bool_output, int(bool_output)


### PR DESCRIPTION
## Summary
- clarify that the node sends HTTP requests to any OpenAI-compatible endpoint
- note that two images can be connected for comparison
- support images in `VisionLLMQuery` and optional server
- test server and node with two-image inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a27fc11c833188c4e0279962b868