### PR TITLE
Support dual-image requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 🚀 **ComfyAI** is an advanced **LLM-powered query node** for **ComfyUI**, enabling both **text-based and vision-based inference** using multimodal models like **Qwen-VL** and **Llava**.  
 
-This project exposes a lightweight HTTP API for text or vision models and can use any OpenAI-compatible endpoint, including the optional ONNX server.
+This project exposes a lightweight HTTP API for text or vision models and can use any OpenAI-compatible endpoint, including the optional ONNX server. The ComfyUI node is fully decoupled from the LLM and communicates purely over HTTP.
 
 ---
 
@@ -11,7 +11,8 @@ This project exposes a lightweight HTTP API for text or vision models and can us
 - ✅ **Text & Vision-Based LLM Inference** – Process **both images and text** in ComfyUI.  
 - ✅ **Multimodal Model Support** – Works with **Qwen-VL**, **Llava**, and more.  
 - ✅ **Stable & Resilient** – Offloads heavy inference to an optional external server.
-- ✅ **Optimized Image Handling** – Minimizes memory usage with **controlled tokenization**.  
+- ✅ **Optimized Image Handling** – Minimizes memory usage with **controlled tokenization**.
+- ☁️ **Decoupled Architecture** – The node communicates with any OpenAI-compatible HTTP endpoint so your LLM can run remotely.
 
 ---
 
@@ -64,7 +65,8 @@ pip install -e .[llm]
 
 ### **📌 Use Case 1 - Single Image → Text Output**  
 
-To **describe an image**, pass it as `sample`. The `reference` input is only used for comparisons.  
+To **describe an image**, pass it as `sample`. The `reference` input is only used for comparisons.
+If you provide **both** `sample` and `reference`, the node will send **two images at once** for vision models that support comparisons.
 
 **Example Workflow:**  
 ![Single Image Example](Example01.png)  

--- a/onnx_vllm_server.py
+++ b/onnx_vllm_server.py
@@ -49,7 +49,15 @@ async def chat(request: Request):
     except ValidationError as e:
         raise HTTPException(status_code=400, detail=e.errors())
 
-    text = req.messages[-1].get("content", "") if req.messages else ""
+    text = ""
+    if req.messages:
+        content = req.messages[-1].get("content", "")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text += part.get("text", "")
+        else:
+            text = str(content)
     result = classify(text)
     return {
         "id": "cmpl-001",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -35,3 +35,18 @@ def test_chat_endpoint_invalid_json(monkeypatch):
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 400
+
+
+def test_chat_endpoint_with_two_images(monkeypatch):
+    client = _client(monkeypatch)
+    msg = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "hi"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,a"}},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,b"}},
+        ],
+    }
+    resp = client.post("/v1/chat/completions", json={"model": "test", "messages": [msg]})
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["message"]["content"] == "positive"

--- a/tests/test_vllm_query.py
+++ b/tests/test_vllm_query.py
@@ -1,0 +1,32 @@
+import vllm_query
+
+
+def test_run_with_two_images(monkeypatch):
+    node = vllm_query.VisionLLMQuery()
+
+    called = {}
+
+    def fake_chat(endpoint, model, messages, api_key=None, timeout=30, **kw):
+        called["messages"] = messages
+        return "yes"
+
+    monkeypatch.setattr(vllm_query, "chat_completion", fake_chat)
+    monkeypatch.setattr(vllm_query, "fuzzy_match_bool", lambda x: True)
+    monkeypatch.setattr(vllm_query, "image_to_bytes", lambda img: b"img")
+
+    result = node.run(
+        api_endpoint="http://x",
+        api_model="gpt",
+        api_key="",
+        text_query="hello",
+        image="i1",
+        reference_image="i2",
+    )
+
+    msgs = called["messages"][0]["content"]
+    assert len(msgs) == 3
+    assert msgs[0]["type"] == "text"
+    assert msgs[1]["type"] == "image_url"
+    assert msgs[2]["type"] == "image_url"
+    assert result[1] is True
+

--- a/vllm_query.py
+++ b/vllm_query.py
@@ -1,6 +1,8 @@
 import logging
+import base64
 from string_utils import fuzzy_match_bool
 from openai_client import chat_completion
+from image_utils import image_to_bytes
 
 class VisionLLMQuery:
     @classmethod
@@ -30,7 +32,25 @@ class VisionLLMQuery:
         api_model = inputs.get("api_model", "gpt-3.5-turbo")
         api_key = inputs.get("api_key", "") or None
         text_query = inputs.get("text_query", "")
-        messages = [{"role": "user", "content": text_query}]
+        image = inputs.get("image")
+        reference_image = inputs.get("reference_image")
+
+        content = [{"type": "text", "text": text_query}]
+
+        try:
+            if image is not None:
+                img_b = image_to_bytes(image)
+                encoded = base64.b64encode(img_b).decode()
+                content.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{encoded}"}})
+            if reference_image is not None:
+                ref_b = image_to_bytes(reference_image)
+                encoded = base64.b64encode(ref_b).decode()
+                content.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{encoded}"}})
+        except Exception:
+            logging.exception("Failed to encode image inputs")
+
+        messages = [{"role": "user", "content": content}]
+
         result = chat_completion(api_endpoint, api_model, messages, api_key=api_key)
         bool_output = fuzzy_match_bool(result)
         return result, bool_output, int(bool_output)


### PR DESCRIPTION
## Summary
- support sending up to two images in `VisionLLMQuery`
- parse image/text content in `onnx_vllm_server`
- test sending two images in the API server
- add tests for the ComfyAI node
- document decoupled OpenAI-compatible architecture and dual-image feature

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a27fc11c833188c4e0279962b868