### PR TITLE
Make ONNX server optional, add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install runtime
+        run: pip install -r requirements.txt
+
+      - name: Install dev
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest -ra

--- a/README.md
+++ b/README.md
@@ -154,6 +154,55 @@ to this server, Ollama, or the official OpenAI API.
 
 ---
 
+## Installation & Runners
+
+**Default** (remote OpenAI):
+
+```bash
+pip install comfyai
+```
+
+**Optional ONNX VLLM server**:
+
+```bash
+pip install comfyai[onnx]
+```
+
+### Environment Variables
+
+- `COMFYAI_ENDPOINT` – base URL for API calls (default: `https://api.openai.com/v1`)
+- `COMFYAI_ONNX_PORT` – local ONNX server port (default: `8000`)
+
+### Example Usage
+
+```python
+from comfyai import openai_client
+
+# Remote:
+client = openai_client(api_key="…")
+
+# Local ONNX:
+client = openai_client(endpoint="http://localhost:8000/v1/chat/completions")
+
+response = client.create(
+model="qwen2.5",
+messages=[{"role":"user","content":"Hello"}]
+)
+print(response)
+```
+
+### Testing
+
+Run tests with `pytest`. ONNX-related tests are automatically skipped if
+`onnxruntime` or `fastapi` are not installed.
+
+```bash
+pip install -r requirements-dev.txt
+pytest -q
+```
+
+---
+
 
 ## **📅 Roadmap**  
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,15 @@ py-modules = [
 ]
 
 [project.optional-dependencies]
-onnx = ["fastapi", "uvicorn", "onnxruntime"]
-llm = ["torch", "torchvision"]
-dev = ["pytest", "requests", "fastapi", "httpx", "pillow", "rapidfuzz"]
+onnx = [
+    "onnxruntime>=1.15",
+    "fastapi>=0.95",
+    "uvicorn>=0.22",
+]
+# torch = ["torch>=2.0"]
+
+[project.dev-dependencies]
+pytest = "^7.0"
+pillow = "^9.0"
+numpy = "^1.23"
+requests = "^2.28"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+minversion = 7.0
+addopts = -q
+markers =
+    onnx: mark tests requiring onnxruntime or FastAPI

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pytest>=7.0
+pillow>=9.0
+numpy>=1.23
+requests>=2.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.28
+pillow>=9.0
+numpy>=1.23

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+import pytest
+from PIL import Image
+import numpy as np
+import sys, types
+import os
+
+# Ensure unit test mode for modules that check this env var
+os.environ.setdefault("UNIT_TEST_MODE", "1")
+
+# Add repository root to sys.path so local modules resolve
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+
+# Stub heavy modules so imports never fail
+for mod in ("torch", "onnxruntime", "fastapi", "uvicorn"):
+    sys.modules.setdefault(mod, types.ModuleType(mod))
+
+@pytest.fixture
+def dummy_image():
+    """16×16 black RGB image"""
+    return Image.fromarray(np.zeros((16,16,3), dtype=np.uint8))
+
+@pytest.fixture
+def dummy_string():
+    return "test"
+
+@pytest.fixture
+def dummy_int():
+    return 0
+
+
+def pytest_runtest_setup(item):
+    """Skip tests marked with 'onnx' if optional deps aren't installed."""
+    if "onnx" in item.keywords:
+        import importlib.util
+        if (
+            importlib.util.find_spec("onnxruntime") is None
+            or importlib.util.find_spec("fastapi") is None
+        ):
+            pytest.skip("Skipping ONNX tests; optional extra not installed")
+

--- a/tests/test_ConditionalSaveImage.py
+++ b/tests/test_ConditionalSaveImage.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import types
+import pytest
+
+# Import after setting UNIT_TEST_MODE so the module stubs heavy deps
+os.environ["UNIT_TEST_MODE"] = "1"
+import conditional_save_image
+
+
+class DummyImage:
+    def __init__(self):
+        self._arr = __import__('numpy').zeros((1, 16, 16, 3), dtype='float32')
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._arr
+
+    @property
+    def shape(self):
+        return self._arr.shape
+
+
+def test_contract():
+    cls = conditional_save_image.ConditionalSaveImage
+    assert isinstance(cls.CATEGORY, str)
+    inputs = cls.INPUT_TYPES()
+    assert "condition" in inputs["required"]
+    assert hasattr(cls, cls.FUNCTION)
+
+
+def test_skip_save(monkeypatch):
+    dummy = DummyImage()
+    # Stub folder_paths.get_output_directory and get_save_image_path
+    fp = types.SimpleNamespace(
+        get_output_directory=lambda: "/tmp",
+        get_save_image_path=lambda *a, **k: ("/tmp", "img", 0, "", "img")
+    )
+    monkeypatch.setattr(conditional_save_image, "folder_paths", fp)
+    node = conditional_save_image.ConditionalSaveImage()
+    result = node.save_images(False, [dummy])
+    assert result == {"ui": {"images": []}}

--- a/tests/test_ImageSelector.py
+++ b/tests/test_ImageSelector.py
@@ -1,0 +1,29 @@
+import pytest
+
+try:
+    from custom_nodes.YourPluginName.ImageSelector import ImageSelector
+except Exception:  # pragma: no cover - optional node
+    ImageSelector = None
+
+if ImageSelector is None:
+    pytest.skip("ImageSelector node not available", allow_module_level=True)
+
+
+def test_contract():
+    assert isinstance(ImageSelector.CATEGORY, str)
+    inputs = ImageSelector.INPUT_TYPES()
+    assert isinstance(inputs, dict)
+    assert "required" in inputs
+    assert isinstance(ImageSelector.RETURN_TYPES, tuple)
+    assert hasattr(ImageSelector, ImageSelector.FUNCTION)
+
+
+@pytest.mark.parametrize("fixture_name,arg_name", [("dummy_image", "images")])
+def test_choose_image(fixture_name, arg_name, request):
+    kwargs = {arg_name: request.getfixturevalue(fixture_name)}
+    node = ImageSelector()
+    fn = getattr(node, ImageSelector.FUNCTION)
+    result = fn(**kwargs)
+    from PIL.Image import Image as PILImage
+    assert isinstance(result, tuple) and len(result) == 1
+    assert isinstance(result[0], PILImage)

--- a/tests/test_VisionLLMQuery.py
+++ b/tests/test_VisionLLMQuery.py
@@ -1,0 +1,31 @@
+import pytest
+from vllm_query import VisionLLMQuery
+
+
+def test_contract():
+    assert isinstance(VisionLLMQuery.CATEGORY, str)
+    input_types = VisionLLMQuery.INPUT_TYPES()
+    for name in ("text_query", "api_endpoint", "api_model", "api_key"):
+        assert name in input_types["required"]
+    assert isinstance(VisionLLMQuery.RETURN_TYPES, tuple)
+    assert hasattr(VisionLLMQuery, VisionLLMQuery.FUNCTION)
+
+
+def test_run_minimal(dummy_image, monkeypatch):
+    node = VisionLLMQuery()
+
+    monkeypatch.setattr("vllm_query.chat_completion", lambda *a, **k: "yes")
+    monkeypatch.setattr("vllm_query.fuzzy_match_bool", lambda x: True)
+    monkeypatch.setattr("vllm_query.image_to_bytes", lambda img: b"img")
+
+    result = node.run(
+        api_endpoint="http://x",
+        api_model="gpt",
+        text_query="hello",
+        image=dummy_image,
+    )
+
+    assert isinstance(result, tuple) and len(result) == 3
+    assert isinstance(result[0], str)
+    assert isinstance(result[1], bool)
+    assert isinstance(result[2], int)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,22 @@
 import pytest
-from fastapi.testclient import TestClient
-import onnx_vllm_server
+
+pytestmark = pytest.mark.onnx
+
+try:
+    from fastapi.testclient import TestClient
+    import fastapi  # noqa: F401
+except Exception:  # pragma: no cover - optional
+    TestClient = None
+
+if TestClient is None:
+    pytest.skip("fastapi not available", allow_module_level=True)
+else:
+    import onnx_vllm_server
 
 
 def _client(monkeypatch):
+    if TestClient is None:
+        pytest.skip("fastapi not available")
     # ensure classify returns predictable output
     monkeypatch.setattr(onnx_vllm_server, "classify", lambda text: "positive")
     return TestClient(onnx_vllm_server.app)


### PR DESCRIPTION
## Summary
- keep ONNX/FastAPI extras optional
- add dev requirements and separate core requirements
- document installation and usage
- add pytest fixtures and node tests
- skip FastAPI tests when dependency missing
- add CI workflow

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874a6c56e7083318a367ad2224362fe