### PR TITLE
Add headless ComfyUI workflow test harness

### DIFF
--- a/comfyai/testing/workflow_runner.py
+++ b/comfyai/testing/workflow_runner.py
@@ -1,0 +1,37 @@
+"""Utilities for running tiny ComfyUI graphs headlessly."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from comfyui.workflow_executor import WorkflowExecutor, ExecutionCache
+
+
+def run_workflow_from_json(graph_json: str, base_path: str | None = None) -> Dict[str, Any]:
+    """Execute a minimal graph encoded as JSON.
+
+    Parameters
+    ----------
+    graph_json: str
+        JSON mapping node_id -> {"class_type": str, "inputs": {...}}
+    base_path: str | None
+        Optional base path for ExecutionCache.
+
+    Returns
+    -------
+    dict
+        {"executor": WorkflowExecutor, "outputs": {node_id: output}}
+    """
+    graph = json.loads(graph_json)
+    cache = ExecutionCache(base_path=base_path)
+    executor = WorkflowExecutor(cache=cache)
+    for node_id, spec in graph.items():
+        class_type = spec["class_type"]
+        inputs = spec.get("inputs", {})
+        executor.instantiate_node(str(node_id), class_type, inputs)
+    executor.run_all()
+    return {
+        "executor": executor,
+        "outputs": {nid: cache.get_output(nid) for nid in graph},
+    }

--- a/comfyui/__init__.py
+++ b/comfyui/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal ComfyUI compatibility package used for tests."""

--- a/comfyui/workflow_executor.py
+++ b/comfyui/workflow_executor.py
@@ -1,0 +1,84 @@
+import importlib
+from typing import Any, Dict
+
+
+class ExecutionCache:
+    """Simple cache storing node outputs."""
+
+    def __init__(self, base_path: str | None = None) -> None:
+        self.base_path = base_path
+        self._outputs: Dict[str, Any] = {}
+
+    def set_output(self, node_id: str, value: Any) -> None:
+        self._outputs[node_id] = value
+
+    def get_output(self, node_id: str) -> Any:
+        return self._outputs.get(node_id)
+
+
+class WorkflowExecutor:
+    """Very small workflow executor for tests."""
+
+    def __init__(self, cache: ExecutionCache | None = None) -> None:
+        self.cache = cache or ExecutionCache()
+        self._nodes: Dict[str, tuple[Any, Dict[str, Any]]] = {}
+
+    def _resolve_class(self, class_type: str):
+        """Return node class from custom_nodes or builtin nodes."""
+        try:
+            from custom_nodes import NODE_CLASS_MAPPINGS
+            if class_type in NODE_CLASS_MAPPINGS:
+                return NODE_CLASS_MAPPINGS[class_type]
+        except Exception:
+            pass
+
+        # Attempt to import module from custom_nodes package by scanning all modules
+        try:
+            import pkgutil
+            import custom_nodes
+            for _, mod_name, _ in pkgutil.iter_modules(custom_nodes.__path__):
+                mod = importlib.import_module(f"custom_nodes.{mod_name}")
+                if hasattr(mod, class_type):
+                    return getattr(mod, class_type)
+        except Exception:
+            pass
+
+        # Builtin ComfyUI nodes if available
+        try:
+            import nodes
+            mappings = getattr(nodes, "NODE_CLASS_MAPPINGS", {})
+            if class_type in mappings:
+                return mappings[class_type]
+            if hasattr(nodes, class_type):
+                return getattr(nodes, class_type)
+        except Exception:
+            pass
+
+        raise KeyError(f"Unknown node class: {class_type}")
+
+    def instantiate_node(self, node_id: str, class_type: str, inputs: Dict[str, Any]):
+        cls = self._resolve_class(class_type)
+        instance = cls() if isinstance(cls, type) else cls
+        self._nodes[node_id] = (instance, inputs)
+
+    def _execute_node(self, node_id: str):
+        instance, inputs = self._nodes[node_id]
+        resolved: Dict[str, Any] = {}
+        for key, val in inputs.items():
+            if isinstance(val, list) and len(val) == 2:
+                up_id, slot = val
+                upstream = self.cache.get_output(up_id)
+                if isinstance(upstream, tuple | list):
+                    resolved[key] = upstream[slot]
+                else:
+                    resolved[key] = upstream
+            else:
+                resolved[key] = val
+        func_name = getattr(instance, "FUNCTION", "run")
+        func = getattr(instance, func_name)
+        output = func(**resolved)
+        self.cache.set_output(node_id, output)
+
+    def run_all(self):
+        for node_id in list(self._nodes.keys()):
+            self._execute_node(node_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,3 +41,9 @@ def pytest_runtest_setup(item):
         ):
             pytest.skip("Skipping ONNX tests; optional extra not installed")
 
+
+@pytest.fixture
+def run_graph():
+    """Execute a mini workflow graph using the headless runner."""
+    from comfyai.testing.workflow_runner import run_workflow_from_json
+    return run_workflow_from_json

--- a/tests/test_custom_node_integration.py
+++ b/tests/test_custom_node_integration.py
@@ -1,0 +1,24 @@
+import json
+
+
+def test_vllm_query_in_workflow(run_graph, monkeypatch):
+    """Ensure VisionLLMQuery executes through the workflow runner."""
+    monkeypatch.setattr("custom_nodes.vllm_query.chat_completion", lambda *a, **k: "ok")
+
+    graph = {
+        "1": {
+            "class_type": "VisionLLMQuery",
+            "inputs": {
+                "text_query": "hello",
+                "api_endpoint": "http://localhost",
+                "api_model": "test-model",
+                "api_key": "",
+            },
+        }
+    }
+    result = run_graph(json.dumps(graph))
+    outputs = result["outputs"]
+    assert "1" in outputs
+    out = outputs["1"]
+    assert isinstance(out, tuple)
+    assert out[0] == "ok"


### PR DESCRIPTION
## Summary
- implement a minimal `WorkflowExecutor` and `ExecutionCache`
- expose `run_workflow_from_json` helper under `comfyai.testing`
- add fixture `run_graph` and example integration test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875c0c051c483319642ddb07fb379a6