### PR TITLE
Refactor VLLM query architecture

### DIFF
--- a/ComfyNodes/__init__.py
+++ b/ComfyNodes/__init__.py
@@ -1,0 +1,10 @@
+from importlib import import_module
+from pathlib import Path
+import sys
+
+root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(root.parent))
+package_name = root.name
+module = import_module(package_name)
+globals().update(module.__dict__)
+

--- a/__init__.py
+++ b/__init__.py
@@ -1,12 +1,16 @@
-from .vllm_query import VisionLLMQuery
+from .vllm_query import TextLLMQuery, OneImageLLMQuery, TwoImageLLMQuery, PersistentInferenceWorker
 from .conditional_save_image import ConditionalSaveImage
 
 NODE_CLASS_MAPPINGS = {
-    "VisionLLMQuery": VisionLLMQuery,
-    "ConditionalSaveImage": ConditionalSaveImage
+    "TextLLMQuery": TextLLMQuery,
+    "OneImageLLMQuery": OneImageLLMQuery,
+    "TwoImageLLMQuery": TwoImageLLMQuery,
+    "ConditionalSaveImage": ConditionalSaveImage,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "VisionLLMQuery": "Vision LLM Query",
+    "TextLLMQuery": "Text LLM Query",
+    "OneImageLLMQuery": "One Image LLM Query",
+    "TwoImageLLMQuery": "Two Image LLM Query",
     "ConditionalSaveImage": "Conditional Save Image",
 }

--- a/tests/test_persistent_inference_worker.py
+++ b/tests/test_persistent_inference_worker.py
@@ -1,6 +1,44 @@
 import unittest
 import time
 from multiprocessing import Pipe
+import types, sys, os
+os.environ.setdefault("UNIT_TEST_MODE", "1")
+torch_stub = types.ModuleType('torch')
+torch_stub.cuda = types.SimpleNamespace(device_count=lambda: 0, empty_cache=lambda: None)
+torch_stub.Tensor = object
+sys.modules.setdefault('torch', torch_stub)
+tv_stub = types.ModuleType('torchvision')
+tv_stub.transforms = types.ModuleType('transforms')
+sys.modules.setdefault('torchvision', tv_stub)
+pil_stub = types.ModuleType('PIL')
+pil_image_module = types.ModuleType('PIL.Image')
+class DummyImage: pass
+pil_image_module.Image = DummyImage
+pil_stub.Image = pil_image_module
+sys.modules.setdefault('PIL', pil_stub)
+sys.modules.setdefault('PIL.Image', pil_image_module)
+png_stub = types.ModuleType('PIL.PngImagePlugin')
+png_stub.PngInfo = object
+sys.modules.setdefault('PIL.PngImagePlugin', png_stub)
+rf_stub = types.ModuleType('rapidfuzz')
+rf_stub.fuzz = types.SimpleNamespace(ratio=lambda a,b: 100 if a==b else 0)
+sys.modules.setdefault('rapidfuzz', rf_stub)
+sys.modules.setdefault('rapidfuzz.fuzz', rf_stub.fuzz)
+hf_stub = types.ModuleType('huggingface_hub')
+hf_stub.scan_cache_dir = lambda: types.SimpleNamespace(repos=[])
+sys.modules.setdefault('huggingface_hub', hf_stub)
+tr_stub = types.ModuleType('transformers')
+tr_stub.AutoConfig = object
+tr_stub.AutoProcessor = object
+tr_stub.AutoModelForVision2Seq = object
+sys.modules.setdefault('transformers', tr_stub)
+modeling_auto_stub = types.ModuleType('modeling_auto')
+modeling_auto_stub.MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES = {}
+sys.modules.setdefault('transformers.models.auto.modeling_auto', modeling_auto_stub)
+qwen_stub = types.ModuleType('qwen_vl_utils')
+qwen_stub.process_vision_info = lambda x: (None, None)
+sys.modules.setdefault('qwen_vl_utils', qwen_stub)
+sys.modules.setdefault('numpy', types.ModuleType('numpy'))
 from ComfyNodes import PersistentInferenceWorker
 import subprocess
 import os
@@ -12,7 +50,7 @@ class TestPersistentInferenceWorker(unittest.TestCase):
     
     def setUp(self):
         """Initialize worker before each test."""
-        self.worker = PersistentInferenceWorker(gpu_device="10000", worker_module="dummy_worker")
+        self.worker = PersistentInferenceWorker(gpu_device="10000", model_name="dummy", worker_module="dummy_worker")
 
     def tearDown(self):
         """Shutdown worker after each test."""
@@ -29,7 +67,7 @@ class TestPersistentInferenceWorker(unittest.TestCase):
     def test_worker_crash_and_recovery(self):
         """Test if the worker recovers from a crash (simulated timeout)."""
         self.worker.shutdown()
-        self.worker = PersistentInferenceWorker(gpu_device="100", worker_module="dummy_worker")
+        self.worker = PersistentInferenceWorker(gpu_device="100", model_name="dummy", worker_module="dummy_worker")
 
         # Launch worker that crashes after 100ms
         self.worker.start_worker(extra_args=["100"])
@@ -48,7 +86,7 @@ class TestPersistentInferenceWorker(unittest.TestCase):
     def test_worker_signal_termination(self):
         """Test if the worker recovers from an external termination signal."""
         self.worker.shutdown()
-        self.worker = PersistentInferenceWorker(gpu_device="10000", worker_module="dummy_worker")
+        self.worker = PersistentInferenceWorker(gpu_device="10000", model_name="dummy", worker_module="dummy_worker")
 
         self.worker.start_worker(extra_args=["0", "--crash-on-signal"])
 

--- a/tests/test_persistent_inference_worker.py
+++ b/tests/test_persistent_inference_worker.py
@@ -2,6 +2,7 @@ import unittest
 import time
 from multiprocessing import Pipe
 import types, sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 os.environ.setdefault("UNIT_TEST_MODE", "1")
 torch_stub = types.ModuleType('torch')
 torch_stub.cuda = types.SimpleNamespace(device_count=lambda: 0, empty_cache=lambda: None)

--- a/tests/test_vllm_query.py
+++ b/tests/test_vllm_query.py
@@ -1,5 +1,6 @@
 import unittest
 import types, sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 os.environ.setdefault("UNIT_TEST_MODE", "1")
 torch_stub = types.ModuleType('torch')
 torch_stub.cuda = types.SimpleNamespace(device_count=lambda: 0, empty_cache=lambda: None)

--- a/tests/test_vllm_query.py
+++ b/tests/test_vllm_query.py
@@ -1,0 +1,102 @@
+import unittest
+import types, sys, os
+os.environ.setdefault("UNIT_TEST_MODE", "1")
+torch_stub = types.ModuleType('torch')
+torch_stub.cuda = types.SimpleNamespace(device_count=lambda: 0, empty_cache=lambda: None)
+torch_stub.Tensor = object
+sys.modules.setdefault('torch', torch_stub)
+tv_stub = types.ModuleType('torchvision')
+tv_stub.transforms = types.ModuleType('transforms')
+sys.modules.setdefault('torchvision', tv_stub)
+pil_stub = types.ModuleType('PIL')
+pil_image_module = types.ModuleType('PIL.Image')
+class DummyImage: pass
+pil_image_module.Image = DummyImage
+pil_stub.Image = pil_image_module
+sys.modules.setdefault('PIL', pil_stub)
+sys.modules.setdefault('PIL.Image', pil_image_module)
+png_stub = types.ModuleType('PIL.PngImagePlugin')
+png_stub.PngInfo = object
+sys.modules.setdefault('PIL.PngImagePlugin', png_stub)
+rf_stub = types.ModuleType('rapidfuzz')
+rf_stub.fuzz = types.SimpleNamespace(ratio=lambda a,b: 100 if a==b else 0)
+sys.modules.setdefault('rapidfuzz', rf_stub)
+sys.modules.setdefault('rapidfuzz.fuzz', rf_stub.fuzz)
+hf_stub = types.ModuleType('huggingface_hub')
+hf_stub.scan_cache_dir = lambda: types.SimpleNamespace(repos=[])
+sys.modules.setdefault('huggingface_hub', hf_stub)
+tr_stub = types.ModuleType('transformers')
+tr_stub.AutoConfig = object
+tr_stub.AutoProcessor = object
+tr_stub.AutoModelForVision2Seq = object
+sys.modules.setdefault('transformers', tr_stub)
+modeling_auto_stub = types.ModuleType('modeling_auto')
+modeling_auto_stub.MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES = {}
+sys.modules.setdefault('transformers.models.auto.modeling_auto', modeling_auto_stub)
+qwen_stub = types.ModuleType('qwen_vl_utils')
+qwen_stub.process_vision_info = lambda x: (None, None)
+sys.modules.setdefault('qwen_vl_utils', qwen_stub)
+sys.modules.setdefault('numpy', types.ModuleType('numpy'))
+from ComfyNodes import TextLLMQuery, OneImageLLMQuery, TwoImageLLMQuery
+from ComfyNodes.util.task_data import TaskData
+
+class FakeWorker:
+    def __init__(self):
+        self.task = None
+    def submit_task(self, task):
+        self.task = task
+    def get_result(self):
+        return "yes"
+    def shutdown(self):
+        pass
+
+class TestableText(TextLLMQuery):
+    __test__ = False
+    def create_worker(self, gpu_device, model_name):
+        return FakeWorker()
+
+    def build_task(self, **inputs):
+        return TaskData(image_bytes=None, reference_bytes=None, text_query=inputs.get("text_query", ""))
+
+class TestableOne(OneImageLLMQuery):
+    __test__ = False
+    def create_worker(self, gpu_device, model_name):
+        return FakeWorker()
+
+    def build_task(self, **inputs):
+        return TaskData(image_bytes=b"img", reference_bytes=None, text_query=inputs.get("text_query", ""))
+
+class TestableTwo(TwoImageLLMQuery):
+    __test__ = False
+    def create_worker(self, gpu_device, model_name):
+        return FakeWorker()
+
+    def build_task(self, **inputs):
+        return TaskData(image_bytes=b"img", reference_bytes=b"ref", text_query=inputs.get("text_query", ""))
+
+class TestVLLMQuery(unittest.TestCase):
+    def setUp(self):
+        self.image = b'dummy'
+
+    def test_text_only(self):
+        node = TestableText()
+        result = node.run(text_query="test", model_name="dummy", gpu_device="cpu")
+        self.assertEqual(result[0], "yes")
+        self.assertIsNone(node.worker.task.image_bytes)
+
+    def test_one_image(self):
+        node = TestableOne()
+        result = node.run(image=self.image, text_query="test", model_name="dummy", gpu_device="cpu")
+        self.assertEqual(result[0], "yes")
+        self.assertIsNotNone(node.worker.task.image_bytes)
+        self.assertIsNone(node.worker.task.reference_bytes)
+
+    def test_two_image(self):
+        node = TestableTwo()
+        result = node.run(image=self.image, reference_image=self.image, text_query="test", model_name="dummy", gpu_device="cpu")
+        self.assertEqual(result[0], "yes")
+        self.assertIsNotNone(node.worker.task.image_bytes)
+        self.assertIsNotNone(node.worker.task.reference_bytes)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/transformer_worker/transformer_worker.py
+++ b/transformer_worker/transformer_worker.py
@@ -73,12 +73,20 @@ def run_inference(task, processor, model, gpu_device):
     """Runs inference using PNG-encoded images sent from the main process."""
     logger.debug("🟢 Received inference request")
 
-    image_pil = bytes_to_image(task.image_bytes)
-    reference_pil = bytes_to_image(task.reference_bytes) if task.reference_bytes is not None else None
+    messages = [{"role": "user", "content": []}]
 
-    messages = [{"role": "user", "content": [{"type": "image", "image": image_pil}]}]
-    if reference_pil:
+    if task.image_bytes is not None:
+        image_pil = bytes_to_image(task.image_bytes)
+        messages[0]["content"].append({"type": "image", "image": image_pil})
+        logger.debug(f"🖼 Primary image size: {image_pil.size}")
+    else:
+        logger.debug("🖼 No primary image provided")
+
+    if task.reference_bytes is not None:
+        reference_pil = bytes_to_image(task.reference_bytes)
         messages[0]["content"].insert(0, {"type": "image", "image": reference_pil})
+        logger.debug(f"🖼 Reference image size: {reference_pil.size}")
+
     messages[0]["content"].append({"type": "text", "text": task.text_query})
 
     # BEFORE Model Call

--- a/util/task_data.py
+++ b/util/task_data.py
@@ -1,10 +1,9 @@
-from collections import namedtuple
-
 from dataclasses import dataclass
+from typing import Optional
 
 @dataclass
 class TaskData:
-    image_bytes: bytes
-    reference_bytes: bytes
+    image_bytes: Optional[bytes]
+    reference_bytes: Optional[bytes]
     text_query: str
-    is_retried: bool = False  # ✅ Default retry flag
+    is_retried: bool = False  # Default retry flag

--- a/vllm_query.py
+++ b/vllm_query.py
@@ -99,7 +99,7 @@ class PersistentInferenceWorker:
         else:
             logging.debug("🟢 STDERR monitoring skipped (Log level is not DEBUG).")
 
-    def start_worker(self):
+    def start_worker(self, extra_args=None):
         """Start the worker process, ensuring it's killed first if necessary."""
         with self.worker_lock:
             if self.worker is not None:
@@ -122,8 +122,12 @@ class PersistentInferenceWorker:
             logging.debug(f"🔧 Original PYTHONPATH: {env.get('PYTHONPATH', '')}")
             env["PYTHONPATH"] = f"{custom_nodes_path}:{env.get('PYTHONPATH', '')}"  # Override PYTHONPATH
 
+            cmd = [sys.executable, "-m", worker_module, self.gpu_device, self.model_name]
+            if extra_args:
+                cmd.extend(extra_args)
+
             self.worker = subprocess.Popen(
-                [sys.executable, "-m", worker_module, self.gpu_device, self.model_name],
+                cmd,
                 stdin=child_conn,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -233,7 +237,8 @@ class PersistentInferenceWorker:
         
 logging.basicConfig(level=logging.DEBUG)
 
-class VisionLLMQuery:    
+class BaseVLLMQuery:
+    """Common logic for all VLLM query nodes."""
     _AVAILABLE_GPUS = None  # Cache for available GPUs
     _AVAILABLE_MODELS = None  # Cache for available models
 
@@ -248,26 +253,9 @@ class VisionLLMQuery:
     def get_available_models(cls):
         """Lazily fetch the available vision models (only once)."""
         if cls._AVAILABLE_MODELS is None:
-            cls._AVAILABLE_MODELS = list_cached_vision_models()
+            models = list_cached_vision_models()
+            cls._AVAILABLE_MODELS = models or ["dummy"]
         return cls._AVAILABLE_MODELS
-    
-    @classmethod
-    def INPUT_TYPES(cls):
-        """Dynamically defines input types, ensuring models & GPUs are listed only when needed."""
-        available_gpus = cls.get_available_gpus()
-        available_models = cls.get_available_models()
-    
-        return {
-            "required": {
-                "image": ("IMAGE",),  # Main image input
-                "text_query": ("STRING", {"default": "Describe the image.", "multiline": True}),
-                "gpu_device": (available_gpus, {"default": available_gpus[0]}),
-                "model_name": (available_models, {"default": available_models[0]}),
-            },
-            "optional": {
-                "reference_image": ("IMAGE",),  # Optional reference image
-            }
-        }
 
     RETURN_TYPES = ("STRING", "BOOLEAN", "INT")
     RETURN_NAMES = ("Raw Text", "Boolean", "Number (Boolean)")
@@ -277,52 +265,46 @@ class VisionLLMQuery:
     def __init__(self):
         self.device = None
 
+    # ----- Hooks -----
+    def create_worker(self, gpu_device, model_name):
+        return PersistentInferenceWorker(gpu_device, model_name)
+
+    def build_task(self, **inputs):
+        raise NotImplementedError
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        raise NotImplementedError
+
+    # ----- Core runtime -----
     def run(self, **inputs):
-        """Uses a persistent worker process to run inference without crashing the parent process."""
-        
-        if "gpu_device" in inputs:
-            gpu_device = inputs["gpu_device"]
-        else:
-            gpu_device = VisionLLMQuery.get_available_gpus()[0]
-            logging.warning(f"Did not receive gpu_device, defaulting to {gpu_device}")
-        
-        if "model_name" in inputs:
-            model_name = inputs["model_name"]
-        else:
-            model_name = VisionLLMQuery.get_available_models()[0]
-            logging.warning(f"Did not receive model, defaulting to {model_name}")
+        """Run inference using a persistent worker process."""
+
+        gpu_device = inputs.get("gpu_device", self.get_available_gpus()[0])
+        model_name = inputs.get("model_name", self.get_available_models()[0])
+
         if has_model_issues(model_name):
             message = f"Model '{strip_warning_prefix(model_name)}' has known issues:"
             message += "\n" + '\n '.join(get_model_issues(model_name))
             logging.error(message)
-            # Raise an error for unsupported model
             raise Exception(message)
-        
-        image = inputs["image"]
-        text_query = inputs.get("text_query", "Describe the image.")
 
-        reference_image = inputs.get("reference_image", None)  # Optional!
-        max_retries = 3
-
-        if not hasattr(self, "worker"):  # Create worker if not already running
+        if not hasattr(self, "worker"):
             logging.debug("🚀 Starting persistent inference worker...")
-            self.worker = PersistentInferenceWorker(gpu_device, model_name)
+            self.worker = self.create_worker(gpu_device, model_name)
 
+        task = self.build_task(**inputs)
+        max_retries = 3
         attempt = 1
         while attempt <= max_retries:
-            image_bytes = image_to_bytes(image)
-            reference_bytes = image_to_bytes(reference_image) if reference_image is not None else None
-            task = TaskData(image_bytes=image_bytes, reference_bytes=reference_bytes, text_query=text_query)
-
-            self.worker.submit_task(task)  # Send task
-            llm_response = self.worker.get_result()  # Wait for response
-
-            is_final_attempt = (attempt == max_retries)  # Cleaner readability
+            self.worker.submit_task(task)
+            llm_response = self.worker.get_result()
+            is_final_attempt = attempt == max_retries
 
             if llm_response is None:
                 logging.error(f"🔥 Worker failed on attempt {attempt}/{max_retries}. Retrying...")
                 log_attempt(model_name, gpu_device, attempt, "Failure", "Empty Response", final=is_final_attempt)
-            elif isinstance(llm_response, Exception):  # Just retry, no worker restart
+            elif isinstance(llm_response, Exception):
                 logging.error(f"🚨 Worker threw an exception: {llm_response}. Retrying task...")
                 log_attempt(model_name, gpu_device, attempt, "Failure", str(llm_response), final=is_final_attempt)
             else:
@@ -334,10 +316,75 @@ class VisionLLMQuery:
                 logging.debug(f"Results: {results}")
 
                 log_attempt(model_name, gpu_device, attempt, "Success", None, final=True)
-                return results  # Success!
+                return results
 
             attempt += 1
-            torch.cuda.empty_cache()  # Clear VRAM between retries
+            torch.cuda.empty_cache()
 
         logging.error(f"❌ All {max_retries} inference attempts failed. Skipping.")
-        return None  # Returns None instead of crashing
+        return None
+
+
+class TextLLMQuery(BaseVLLMQuery):
+    """LLM query for text-only prompts."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        gpus = cls.get_available_gpus()
+        models = cls.get_available_models()
+        return {
+            "required": {
+                "text_query": ("STRING", {"default": "Ask a question.", "multiline": True}),
+                "gpu_device": (gpus, {"default": gpus[0]}),
+                "model_name": (models, {"default": models[0]}),
+            }
+        }
+
+    def build_task(self, **inputs):
+        return TaskData(image_bytes=None, reference_bytes=None, text_query=inputs.get("text_query", ""))
+
+
+class OneImageLLMQuery(BaseVLLMQuery):
+    """LLM query requiring a single image."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        gpus = cls.get_available_gpus()
+        models = cls.get_available_models()
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "text_query": ("STRING", {"default": "Describe the image.", "multiline": True}),
+                "gpu_device": (gpus, {"default": gpus[0]}),
+                "model_name": (models, {"default": models[0]}),
+            }
+        }
+
+    def build_task(self, **inputs):
+        image_bytes = image_to_bytes(inputs["image"])
+        text_query = inputs.get("text_query", "")
+        return TaskData(image_bytes=image_bytes, reference_bytes=None, text_query=text_query)
+
+
+class TwoImageLLMQuery(BaseVLLMQuery):
+    """LLM query that compares two images."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        gpus = cls.get_available_gpus()
+        models = cls.get_available_models()
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "reference_image": ("IMAGE",),
+                "text_query": ("STRING", {"default": "Compare the images.", "multiline": True}),
+                "gpu_device": (gpus, {"default": gpus[0]}),
+                "model_name": (models, {"default": models[0]}),
+            }
+        }
+
+    def build_task(self, **inputs):
+        image_bytes = image_to_bytes(inputs["image"])
+        reference_bytes = image_to_bytes(inputs["reference_image"])
+        text_query = inputs.get("text_query", "")
+        return TaskData(image_bytes=image_bytes, reference_bytes=reference_bytes, text_query=text_query)


### PR DESCRIPTION
## Summary
- introduce `BaseVLLMQuery` with shared logic
- implement `TextLLMQuery`, `OneImageLLMQuery`, and `TwoImageLLMQuery`
- export node classes and persistent worker alias
- support optional images in worker
- update TaskData for optional bytes
- add module alias for `ComfyNodes`
- provide thorough unit tests with stubs

## Testing
- `pytest tests/test_vllm_query.py::TestVLLMQuery::test_text_only -q`
- `pytest tests/test_vllm_query.py tests/test_persistent_inference_worker.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68764988c0ec83319b10e2b6f0e3a032