### PR TITLE
Refactor VLLM query with base class and variants

### DIFF
--- a/custom_nodes/__init__.py
+++ b/custom_nodes/__init__.py
@@ -1,16 +1,24 @@
 import os
 
 if os.getenv("UNIT_TEST_MODE") != "1":
-    from .vllm_query import VisionLLMQuery
+    from .vllm_query import (
+        VLLMTextQuery,
+        VLLMImageQuery,
+        VLLMDualImageQuery,
+    )
     from .conditional_save_image import ConditionalSaveImage
 
     NODE_CLASS_MAPPINGS = {
-        "VisionLLMQuery": VisionLLMQuery,
+        "VLLMTextQuery": VLLMTextQuery,
+        "VLLMImageQuery": VLLMImageQuery,
+        "VLLMDualImageQuery": VLLMDualImageQuery,
         "ConditionalSaveImage": ConditionalSaveImage,
     }
 
     NODE_DISPLAY_NAME_MAPPINGS = {
-        "VisionLLMQuery": "Vision LLM Query",
+        "VLLMTextQuery": "LLM Query (Text Only)",
+        "VLLMImageQuery": "Vision LLM Query (1 Image)",
+        "VLLMDualImageQuery": "Vision LLM Query (2 Images)",
         "ConditionalSaveImage": "Conditional Save Image",
     }
 else:

--- a/custom_nodes/vllm_query.py
+++ b/custom_nodes/vllm_query.py
@@ -4,21 +4,25 @@ from .string_utils import fuzzy_match_bool
 from .openai_client import chat_completion
 from .image_utils import image_to_bytes
 
-class VisionLLMQuery:
+
+class _BaseVLLMQuery:
+    """Common logic for LLM queries."""
+
+    required_images = 0
+
     @classmethod
     def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "text_query": ("STRING", {"default": "Describe the image.", "multiline": True}),
-                "api_endpoint": ("STRING", {"default": "", "multiline": False}),
-                "api_model": ("STRING", {"default": "gpt-3.5-turbo", "multiline": False}),
-                "api_key": ("STRING", {"default": "", "multiline": False}),
-            },
-            "optional": {
-                "image": ("IMAGE",),
-                "reference_image": ("IMAGE",),
-            },
+        required = {
+            "text_query": ("STRING", {"default": "Describe the image.", "multiline": True}),
+            "api_endpoint": ("STRING", {"default": "", "multiline": False}),
+            "api_model": ("STRING", {"default": "gpt-3.5-turbo", "multiline": False}),
+            "api_key": ("STRING", {"default": "", "multiline": False}),
         }
+        if cls.required_images >= 1:
+            required["image"] = ("IMAGE",)
+        if cls.required_images >= 2:
+            required["reference_image"] = ("IMAGE",)
+        return {"required": required}
 
     RETURN_TYPES = ("STRING", "BOOLEAN", "INT")
     RETURN_NAMES = ("Raw Text", "Boolean", "Number (Boolean)")
@@ -32,20 +36,21 @@ class VisionLLMQuery:
         api_model = inputs.get("api_model", "gpt-3.5-turbo")
         api_key = inputs.get("api_key", "") or None
         text_query = inputs.get("text_query", "")
-        image = inputs.get("image")
-        reference_image = inputs.get("reference_image")
+
+        images = []
+        if self.required_images >= 1:
+            images.append(inputs.get("image"))
+        if self.required_images >= 2:
+            images.append(inputs.get("reference_image"))
 
         content = [{"type": "text", "text": text_query}]
 
         try:
-            if image is not None:
-                img_b = image_to_bytes(image)
-                encoded = base64.b64encode(img_b).decode()
-                content.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{encoded}"}})
-            if reference_image is not None:
-                ref_b = image_to_bytes(reference_image)
-                encoded = base64.b64encode(ref_b).decode()
-                content.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{encoded}"}})
+            for img in images:
+                if img is not None:
+                    img_b = image_to_bytes(img)
+                    encoded = base64.b64encode(img_b).decode()
+                    content.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{encoded}"}})
         except Exception:
             logging.exception("Failed to encode image inputs")
 
@@ -53,7 +58,32 @@ class VisionLLMQuery:
 
         result = chat_completion(api_endpoint, api_model, messages, api_key=api_key)
         bool_output = fuzzy_match_bool(result)
-        # Ensure bool_output is a boolean, default to False if None
         if bool_output is None:
             bool_output = False
         return result, bool_output, int(bool_output)
+
+
+class VLLMTextQuery(_BaseVLLMQuery):
+    """LLM text-only query."""
+
+    required_images = 0
+
+
+class VLLMImageQuery(_BaseVLLMQuery):
+    """LLM query with one image."""
+
+    required_images = 1
+
+
+class VLLMDualImageQuery(_BaseVLLMQuery):
+    """LLM query with two images."""
+
+    required_images = 2
+
+
+__all__ = [
+    "_BaseVLLMQuery",
+    "VLLMTextQuery",
+    "VLLMImageQuery",
+    "VLLMDualImageQuery",
+]

--- a/integration_tests/simple_workflow.json
+++ b/integration_tests/simple_workflow.json
@@ -63,7 +63,7 @@
     },
     {
       "id": 1,
-      "type": "VisionLLMQuery",
+      "type": "VLLMDualImageQuery",
       "pos": [
         1121.780029296875,
         638.4500122070312
@@ -148,7 +148,7 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "VisionLLMQuery"
+        "Node name for S&R": "VLLMDualImageQuery"
       },
       "widgets_values": [
         "Describe the Image",

--- a/integration_tests/test_workflow_runner.py
+++ b/integration_tests/test_workflow_runner.py
@@ -15,13 +15,13 @@ def test_vision_llm_query_headless(run_graph, monkeypatch):
 
     graph = {
         "1": {
-            "class_type": "VisionLLMQuery",
+            "class_type": "VLLMTextQuery",
             "inputs": {
                 "text_query": "hello",
                 "api_endpoint": "http://host",
                 "api_model": "gpt",
-                "api_key": ""
-            }
+                "api_key": "",
+            },
         }
     }
 

--- a/tests/test_vllm_query.py
+++ b/tests/test_vllm_query.py
@@ -1,20 +1,35 @@
 import pytest
-from custom_nodes.vllm_query import VisionLLMQuery
+from custom_nodes.vllm_query import (
+    VLLMTextQuery,
+    VLLMImageQuery,
+    VLLMDualImageQuery,
+)
 import custom_nodes.vllm_query as vllm_query
 
 
-def test_contract():
-    cls = VisionLLMQuery
+@pytest.mark.parametrize(
+    "cls,needs_image",
+    [
+        (VLLMTextQuery, 0),
+        (VLLMImageQuery, 1),
+        (VLLMDualImageQuery, 2),
+    ],
+)
+def test_contract(cls, needs_image):
     assert isinstance(cls.CATEGORY, str)
     in_types = cls.INPUT_TYPES()
     for name in ("text_query", "api_endpoint", "api_model", "api_key"):
         assert name in in_types["required"]
+    if needs_image >= 1:
+        assert "image" in in_types["required"]
+    if needs_image >= 2:
+        assert "reference_image" in in_types["required"]
     assert isinstance(cls.RETURN_TYPES, tuple)
     assert hasattr(cls, cls.FUNCTION)
 
 
 def test_run_minimal(dummy_image, monkeypatch):
-    node = VisionLLMQuery()
+    node = VLLMImageQuery()
     monkeypatch.setattr("custom_nodes.vllm_query.chat_completion", lambda *a, **k: "yes")
     monkeypatch.setattr("custom_nodes.vllm_query.fuzzy_match_bool", lambda x: True)
     monkeypatch.setattr("custom_nodes.vllm_query.image_to_bytes", lambda img: b"img")
@@ -31,7 +46,7 @@ def test_run_minimal(dummy_image, monkeypatch):
 
 
 def test_run_with_two_images(monkeypatch):
-    node = VisionLLMQuery()
+    node = VLLMDualImageQuery()
 
     called = {}
 


### PR DESCRIPTION
## Summary
- introduce `_BaseVLLMQuery` with shared run logic
- add `VLLMTextQuery`, `VLLMImageQuery`, `VLLMDualImageQuery`
- map all three nodes in `NODE_DISPLAY_NAME_MAPPINGS`
- update tests and workflow to use the new node names

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68772d4a992883319593cbdc52e28a22