### PR TITLE
Add face comparison API and ComfyUI node

### DIFF
--- a/apps/face_api/Dockerfile
+++ b/apps/face_api/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . /app
+RUN pip install -r requirements.txt
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "7860"]

--- a/apps/face_api/face_model.py
+++ b/apps/face_api/face_model.py
@@ -1,0 +1,34 @@
+import numpy as np
+from io import BytesIO
+from PIL import Image
+
+from insightface.app import FaceAnalysis
+import onnxruntime as ort
+
+_model = None
+
+def _init_model():
+    global _model
+    if _model is None:
+        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        try:
+            if "CUDAExecutionProvider" not in ort.get_available_providers():
+                providers = ["CPUExecutionProvider"]
+        except Exception:
+            providers = ["CPUExecutionProvider"]
+        _model = FaceAnalysis(name="buffalo_l", providers=providers)
+        _model.prepare(ctx_id=0)
+    return _model
+
+def get_embedding(image_bytes: bytes) -> np.ndarray | None:
+    model = _init_model()
+    img = Image.open(BytesIO(image_bytes)).convert("RGB")
+    arr = np.array(img)[:, :, ::-1]  # RGB -> BGR
+    faces = model.get(arr)
+    if not faces:
+        return None
+    face = faces[0]
+    emb = getattr(face, "normed_embedding", None)
+    if emb is None:
+        emb = face.embedding
+    return emb

--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import JSONResponse
+
+import os
+from . import face_model, utils
+
+app = FastAPI()
+
+
+@app.post("/v1/image/compare_faces")
+async def compare_faces(
+    image_a: UploadFile = File(...),
+    image_b: UploadFile = File(...),
+):
+    data_a = await image_a.read()
+    data_b = await image_b.read()
+    emb_a = face_model.get_embedding(data_a)
+    emb_b = face_model.get_embedding(data_b)
+    if emb_a is None or emb_b is None:
+        return JSONResponse(status_code=422, content={"error": "face_not_detected"})
+    similarity = utils.cosine_similarity(emb_a, emb_b)
+    return {"similarity": round(float(similarity), 4)}
+
+
+def main():
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "7860")))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/face_api/requirements.txt
+++ b/apps/face_api/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+insightface
+onnxruntime
+numpy
+pillow

--- a/apps/face_api/utils.py
+++ b/apps/face_api/utils.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+def cosine_similarity(vec1, vec2):
+    return float(np.dot(vec1, vec2) / (np.linalg.norm(vec1) * np.linalg.norm(vec2)))

--- a/nodes/compare_faces.py
+++ b/nodes/compare_faces.py
@@ -1,0 +1,65 @@
+import os
+import tempfile
+import requests
+import numpy as np
+from PIL import Image
+
+
+class CompareFacesNode:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image_a": ("IMAGE",),
+                "image_b": ("IMAGE",),
+                "api_url": (
+                    "STRING",
+                    {"default": "http://127.0.0.1:7860/v1/image/compare_faces"},
+                ),
+                "threshold": (
+                    "FLOAT",
+                    {"default": 0.72, "min": 0.0, "max": 1.0},
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("FLOAT", "BOOLEAN")
+    RETURN_NAMES = ("similarity_score", "same_person")
+    FUNCTION = "run"
+    CATEGORY = "AI/Face"
+
+    def _tensor_to_pil(self, tensor):
+        arr = np.clip(tensor.cpu().numpy() * 255.0, 0, 255).astype("uint8")
+        if arr.ndim == 4:
+            arr = arr[0]
+        if arr.shape[0] == 1:
+            arr = np.repeat(arr, 3, axis=0)
+        arr = np.transpose(arr, (1, 2, 0))
+        return Image.fromarray(arr)
+
+    def run(self, image_a, image_b, api_url, threshold=0.72):
+        tmp_files = []
+        try:
+            for tensor in (image_a, image_b):
+                img = self._tensor_to_pil(tensor)
+                tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+                img.save(tmp.name, format="PNG")
+                tmp_files.append(tmp.name)
+            with open(tmp_files[0], "rb") as fa, open(tmp_files[1], "rb") as fb:
+                resp = requests.post(api_url, files={"image_a": fa, "image_b": fb}, timeout=30)
+            if resp.status_code != 200:
+                return 0.0, False
+            data = resp.json()
+            sim = float(data.get("similarity", 0.0))
+            return sim, sim >= threshold
+        except Exception:
+            return 0.0, False
+        finally:
+            for path in tmp_files:
+                try:
+                    os.unlink(path)
+                except Exception:
+                    pass
+
+
+__all__ = ["CompareFacesNode"]

--- a/tests/test_face_api.py
+++ b/tests/test_face_api.py
@@ -1,0 +1,70 @@
+import sys
+sys.modules.pop("fastapi", None)
+sys.modules.pop("uvicorn", None)
+sys.modules.pop("onnxruntime", None)
+import io
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.onnx
+
+try:
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - optional
+    TestClient = None
+
+from apps.face_api import main, face_model
+
+
+@pytest.fixture
+def dummy_image_bytes():
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), color="white").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _client(monkeypatch, embeds):
+    if TestClient is None:
+        pytest.skip("fastapi not available")
+    seq = iter(embeds)
+
+    def fake_get(_):
+        return next(seq)
+
+    monkeypatch.setattr(face_model, "get_embedding", fake_get)
+    return TestClient(main.app)
+
+
+def test_compare_faces_success(monkeypatch, dummy_image_bytes):
+    emb = np.array([1.0, 0.0])
+    client = _client(monkeypatch, [emb, emb])
+    resp = client.post(
+        "/v1/image/compare_faces",
+        files={"image_a": ("a.png", dummy_image_bytes, "image/png"),
+               "image_b": ("b.png", dummy_image_bytes, "image/png")},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["similarity"] == pytest.approx(1.0)
+
+
+def test_compare_faces_low(monkeypatch, dummy_image_bytes):
+    client = _client(monkeypatch, [np.array([1.0, 0.0]), np.array([0.0, 1.0])])
+    resp = client.post(
+        "/v1/image/compare_faces",
+        files={"image_a": ("a.png", dummy_image_bytes, "image/png"),
+               "image_b": ("b.png", dummy_image_bytes, "image/png")},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["similarity"] == pytest.approx(0.0)
+
+
+def test_face_not_detected(monkeypatch, dummy_image_bytes):
+    client = _client(monkeypatch, [None, np.array([1.0, 0.0])])
+    resp = client.post(
+        "/v1/image/compare_faces",
+        files={"image_a": ("a.png", dummy_image_bytes, "image/png"),
+               "image_b": ("b.png", dummy_image_bytes, "image/png")},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"] == "face_not_detected"

--- a/tests/test_node_compare_faces.py
+++ b/tests/test_node_compare_faces.py
@@ -1,0 +1,46 @@
+import types
+import numpy as np
+import requests
+
+from nodes.compare_faces import CompareFacesNode
+
+
+class DummyImage:
+    def __init__(self):
+        self._arr = np.zeros((1, 3, 8, 8), dtype="float32")
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._arr
+
+    @property
+    def shape(self):
+        return self._arr.shape
+
+
+def test_node_success(monkeypatch):
+    node = CompareFacesNode()
+
+    def fake_post(url, files=None, timeout=None):
+        resp = types.SimpleNamespace(status_code=200, json=lambda: {"similarity": 0.8})
+        return resp
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    img = DummyImage()
+    result = node.run(img, img, api_url="http://x", threshold=0.72)
+    assert result == (0.8, True)
+
+
+def test_node_error(monkeypatch):
+    node = CompareFacesNode()
+
+    def fake_post(url, files=None, timeout=None):
+        resp = types.SimpleNamespace(status_code=422, json=lambda: {"error": "face_not_detected"})
+        return resp
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    img = DummyImage()
+    result = node.run(img, img, api_url="http://x")
+    assert result == (0.0, False)


### PR DESCRIPTION
## Summary
- implement GPU-aware face comparison FastAPI server using InsightFace
- add CompareFacesNode for uploading image pairs and getting similarity
- include Dockerfile and requirements for API server
- add unit tests for the server and node

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773527ef888331b8a7beba2f227770