### PR TITLE
Add face comparison API and node

### DIFF
--- a/apps/face_api/Dockerfile
+++ b/apps/face_api/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "7860"]

--- a/apps/face_api/face_model.py
+++ b/apps/face_api/face_model.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import io
+from typing import Optional
+
+import numpy as np
+from PIL import Image
+
+try:
+    from insightface.app import FaceAnalysis
+    import onnxruntime as ort
+except Exception:  # pragma: no cover - optional heavy deps
+    FaceAnalysis = None  # type: ignore
+    ort = None  # type: ignore
+
+_model: FaceAnalysis | None = None
+
+
+def _load_model() -> FaceAnalysis | None:
+    global _model
+    if _model is None and FaceAnalysis is not None:
+        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        if ort is not None:
+            available = ort.get_available_providers()
+            if "CUDAExecutionProvider" not in available:
+                providers = ["CPUExecutionProvider"]
+        _model = FaceAnalysis(name="buffalo_l", providers=providers)
+        _model.prepare(ctx_id=0)
+    return _model
+
+
+def get_embedding(image_bytes: bytes) -> Optional[np.ndarray]:
+    """Return face embedding for the first detected face or None."""
+    model = _load_model()
+    if model is None:
+        return None
+    try:
+        img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    except Exception:
+        return None
+    faces = model.get(np.array(img))
+    if not faces:
+        return None
+    return faces[0].normed_embedding

--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import JSONResponse
+
+from .face_model import get_embedding
+from .utils import cosine_similarity
+
+app = FastAPI()
+
+
+@app.post("/v1/image/compare_faces")
+async def compare_faces(image_a: UploadFile = File(...), image_b: UploadFile = File(...)):
+    data_a = await image_a.read()
+    data_b = await image_b.read()
+    emb_a = get_embedding(data_a)
+    emb_b = get_embedding(data_b)
+    if emb_a is None or emb_b is None:
+        return JSONResponse(status_code=422, content={"error": "face_not_detected"})
+    similarity = cosine_similarity(emb_a, emb_b)
+    return {"similarity": float(similarity)}
+
+
+def main():  # pragma: no cover - utility
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=7860)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    main()

--- a/apps/face_api/requirements.txt
+++ b/apps/face_api/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+numpy
+pillow
+insightface

--- a/apps/face_api/utils.py
+++ b/apps/face_api/utils.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+
+def cosine_similarity(vec1, vec2):
+    """Compute cosine similarity between two numpy vectors."""
+    return float(np.dot(vec1, vec2) / (np.linalg.norm(vec1) * np.linalg.norm(vec2)))

--- a/nodes/compare_faces.py
+++ b/nodes/compare_faces.py
@@ -1,0 +1,63 @@
+import os
+import tempfile
+import requests
+
+try:
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - optional
+    torch = None  # type: ignore
+
+from custom_nodes.image_utils import tensor_to_pil
+
+
+class CompareFacesNode:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image_a": ("IMAGE",),
+                "image_b": ("IMAGE",),
+                "api_url": ("STRING", {"default": "http://127.0.0.1:7860/v1/image/compare_faces"}),
+                "threshold": ("FLOAT", {"default": 0.72, "min": 0.0, "max": 1.0}),
+            }
+        }
+
+    RETURN_TYPES = ("FLOAT", "BOOLEAN")
+    RETURN_NAMES = ("similarity_score", "same_person")
+    FUNCTION = "run"
+    CATEGORY = "AI/Faces"
+
+    def run(self, image_a, image_b, api_url, threshold=0.72):
+        if torch is None:
+            raise RuntimeError("torch is required")
+
+        tmp_files = []
+        try:
+            for tensor in (image_a, image_b):
+                img = tensor_to_pil(tensor)
+                fd, path = tempfile.mkstemp(suffix=".png")
+                os.close(fd)
+                img.save(path, format="PNG")
+                tmp_files.append(path)
+
+            with open(tmp_files[0], "rb") as f1, open(tmp_files[1], "rb") as f2:
+                files = {"image_a": f1, "image_b": f2}
+                try:
+                    resp = requests.post(api_url, files=files, timeout=30)
+                    resp.raise_for_status()
+                    data = resp.json()
+                except Exception:
+                    return 0.0, False
+
+            similarity = float(data.get("similarity", 0.0))
+            same = similarity >= float(threshold)
+            return similarity, same
+        finally:
+            for p in tmp_files:
+                try:
+                    os.remove(p)
+                except Exception:
+                    pass
+
+
+__all__ = ["CompareFacesNode"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,12 @@ if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
 # Stub heavy modules so imports never fail
+import importlib.machinery
 for mod in ("torch", "onnxruntime", "fastapi", "uvicorn"):
-    sys.modules.setdefault(mod, types.ModuleType(mod))
+    if mod not in sys.modules:
+        module = types.ModuleType(mod)
+        module.__spec__ = importlib.machinery.ModuleSpec(mod, loader=None)
+        sys.modules[mod] = module
 
 @pytest.fixture
 def dummy_image():

--- a/tests/test_face_api.py
+++ b/tests/test_face_api.py
@@ -1,0 +1,43 @@
+import numpy as np
+import importlib, sys
+sys.modules.pop("fastapi", None)
+from fastapi.testclient import TestClient
+from apps.face_api.main import app
+import apps.face_api.face_model as face_model
+import apps.face_api.main as api_main
+from apps.face_api.utils import cosine_similarity
+
+client = TestClient(app)
+
+
+def test_compare_faces_success(monkeypatch):
+    emb_a = np.array([1.0, 0.0])
+    emb_b = np.array([0.5, 0.5])
+
+    def fake_get_embedding(data):
+        if data == b"A":
+            return emb_a
+        if data == b"B":
+            return emb_b
+        return None
+
+    monkeypatch.setattr(face_model, "get_embedding", fake_get_embedding)
+    monkeypatch.setattr(api_main, "get_embedding", fake_get_embedding)
+    resp = client.post(
+        "/v1/image/compare_faces",
+        files={"image_a": ("a.png", b"A"), "image_b": ("b.png", b"B")},
+    )
+    assert resp.status_code == 200
+    sim = resp.json()["similarity"]
+    assert abs(sim - cosine_similarity(emb_a, emb_b)) < 1e-6
+
+
+def test_face_not_detected(monkeypatch):
+    monkeypatch.setattr(face_model, "get_embedding", lambda data: None)
+    monkeypatch.setattr(api_main, "get_embedding", lambda data: None)
+    resp = client.post(
+        "/v1/image/compare_faces",
+        files={"image_a": ("a.png", b"A"), "image_b": ("b.png", b"B")},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"] == "face_not_detected"

--- a/tests/test_node_compare_faces.py
+++ b/tests/test_node_compare_faces.py
@@ -1,0 +1,76 @@
+import numpy as np
+import requests
+import importlib, sys
+sys.modules.pop("fastapi", None)
+from fastapi.testclient import TestClient
+
+from apps.face_api.main import app
+import apps.face_api.face_model as face_model
+from nodes.compare_faces import CompareFacesNode
+import apps.face_api.main as api_main
+
+client = TestClient(app)
+
+
+def _setup_fake_embeddings(monkeypatch):
+    emb_a = np.array([1.0, 0.0])
+    emb_b = np.array([0.5, 0.5])
+
+    calls = []
+    def fake_get_embedding(data):
+        calls.append(data)
+        return emb_a if len(calls) == 1 else emb_b
+
+    monkeypatch.setattr(face_model, "get_embedding", fake_get_embedding)
+    monkeypatch.setattr(api_main, "get_embedding", fake_get_embedding)
+    return emb_a, emb_b
+
+
+def test_node_compare_faces(dummy_image, monkeypatch):
+    emb_a, emb_b = _setup_fake_embeddings(monkeypatch)
+
+    def fake_post(url, files=None, timeout=30):
+        resp = client.post("/v1/image/compare_faces", files=files)
+        class R:
+            status_code = resp.status_code
+            def raise_for_status(self):
+                if self.status_code >= 400:
+                    raise requests.HTTPError()
+        
+            def json(self):
+                return resp.json()
+        return R()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr("nodes.compare_faces.tensor_to_pil", lambda x: x)
+
+    node = CompareFacesNode()
+    sim, same = node.run(dummy_image, dummy_image, api_url="http://test", threshold=0.7)
+    from apps.face_api.utils import cosine_similarity
+    assert abs(sim - cosine_similarity(emb_a, emb_b)) < 1e-6
+    assert same is True
+
+
+def test_node_error(dummy_image, monkeypatch):
+    monkeypatch.setattr(face_model, "get_embedding", lambda d: None)
+    monkeypatch.setattr(api_main, "get_embedding", lambda d: None)
+
+    def fake_post(url, files=None, timeout=30):
+        resp = client.post("/v1/image/compare_faces", files=files)
+        class R:
+            status_code = resp.status_code
+            def raise_for_status(self):
+                if self.status_code >= 400:
+                    raise requests.HTTPError()
+        
+            def json(self):
+                return resp.json()
+        return R()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr("nodes.compare_faces.tensor_to_pil", lambda x: x)
+
+    node = CompareFacesNode()
+    sim, same = node.run(dummy_image, dummy_image, api_url="http://test")
+    assert sim == 0.0 and same is False
+


### PR DESCRIPTION
## Summary
- implement a small FastAPI service for facial comparison using InsightFace
- add cosine similarity helper
- add ComfyUI node `CompareFacesNode` for comparing two images via the API
- include tests for the API and the new node
- adjust test stubs for heavy modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773527ef888331b8a7beba2f227770