### PR TITLE
Add face comparison feature

### DIFF
--- a/apps/face_api/Dockerfile
+++ b/apps/face_api/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . /app
+RUN pip install -r requirements.txt
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "7860"]

--- a/apps/face_api/face_model.py
+++ b/apps/face_api/face_model.py
@@ -1,0 +1,37 @@
+import io
+from functools import lru_cache
+from typing import Optional
+
+import numpy as np
+from PIL import Image
+
+try:
+    from insightface.app import FaceAnalysis
+except Exception:  # pragma: no cover - optional dependency
+    FaceAnalysis = None  # type: ignore
+
+
+@lru_cache(maxsize=1)
+def get_model():
+    if FaceAnalysis is None:
+        raise RuntimeError("InsightFace is not available")
+    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    app = FaceAnalysis(name="buffalo_l", providers=providers)
+    app.prepare(ctx_id=0, det_size=(640, 640))
+    return app
+
+
+def get_embedding(image_bytes: bytes) -> Optional[np.ndarray]:
+    """Return the embedding vector for the first detected face."""
+    if FaceAnalysis is None:
+        return None
+    try:
+        img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    except Exception:
+        return None
+    img_np = np.array(img)[..., ::-1]  # RGB to BGR
+    model = get_model()
+    faces = model.get(img_np)
+    if not faces:
+        return None
+    return faces[0].normed_embedding

--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import JSONResponse
+
+from . import face_model, utils
+
+app = FastAPI()
+
+
+@app.post("/v1/image/compare_faces")
+async def compare_faces(image_a: UploadFile = File(...), image_b: UploadFile = File(...)):
+    data_a = await image_a.read()
+    data_b = await image_b.read()
+    emb_a = face_model.get_embedding(data_a)
+    emb_b = face_model.get_embedding(data_b)
+    if emb_a is None or emb_b is None:
+        return JSONResponse(status_code=422, content={"error": "face_not_detected"})
+    similarity = utils.cosine_similarity(emb_a, emb_b)
+    return {"similarity": similarity}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=7860)

--- a/apps/face_api/requirements.txt
+++ b/apps/face_api/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+insightface
+numpy
+pillow

--- a/apps/face_api/utils.py
+++ b/apps/face_api/utils.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+
+def cosine_similarity(vec1: np.ndarray, vec2: np.ndarray) -> float:
+    """Return cosine similarity between two vectors."""
+    return float(np.dot(vec1, vec2) / (np.linalg.norm(vec1) * np.linalg.norm(vec2)))

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -1,0 +1,1 @@
+"""Custom nodes for ComfyAI."""

--- a/nodes/compare_faces.py
+++ b/nodes/compare_faces.py
@@ -1,0 +1,84 @@
+import os
+import tempfile
+from typing import Tuple
+
+import requests
+from PIL import Image
+
+from custom_nodes.image_utils import tensor_to_pil
+
+
+class CompareFacesNode:
+    """Send two face images to a comparison API and return similarity."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image_a": ("IMAGE",),
+                "image_b": ("IMAGE",),
+                "api_url": (
+                    "STRING",
+                    {"default": "http://127.0.0.1:7860/v1/image/compare_faces"},
+                ),
+                "threshold": (
+                    "FLOAT",
+                    {"default": 0.72, "min": 0.0, "max": 1.0},
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("FLOAT", "BOOLEAN")
+    RETURN_NAMES = ("similarity_score", "same_person")
+    FUNCTION = "compare"
+    CATEGORY = "image"
+
+    def compare(
+        self,
+        image_a,
+        image_b,
+        api_url: str = "http://127.0.0.1:7860/v1/image/compare_faces",
+        threshold: float = 0.72,
+    ) -> Tuple[float, bool]:
+        tmp_files = []
+        similarity = 0.0
+        same = False
+        try:
+            pil_a = tensor_to_pil(image_a)
+            pil_b = tensor_to_pil(image_b)
+            f1 = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+            pil_a.save(f1, format="PNG")
+            f1.close()
+            tmp_files.append(f1.name)
+
+            f2 = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+            pil_b.save(f2, format="PNG")
+            f2.close()
+            tmp_files.append(f2.name)
+
+            with open(f1.name, "rb") as fa, open(f2.name, "rb") as fb:
+                resp = requests.post(
+                    api_url,
+                    files={
+                        "image_a": ("image_a.png", fa, "image/png"),
+                        "image_b": ("image_b.png", fb, "image/png"),
+                    },
+                    timeout=30,
+                )
+            if resp.status_code == 200:
+                data = resp.json()
+                similarity = float(data.get("similarity", 0.0))
+                same = similarity >= threshold
+        except Exception:
+            similarity = 0.0
+            same = False
+        finally:
+            for p in tmp_files:
+                try:
+                    os.remove(p)
+                except Exception:
+                    pass
+        return similarity, same
+
+
+__all__ = ["CompareFacesNode"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,7 @@ pytest>=7.0
 pillow>=9.0
 numpy>=1.23
 requests>=2.28
+
+fastapi
+httpx
+python-multipart

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,16 @@ repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
-# Stub heavy modules so imports never fail
+# Stub heavy modules so imports never fail. Only create stubs if the
+# real package is missing to allow optional deps when installed.
+import importlib.util
 for mod in ("torch", "onnxruntime", "fastapi", "uvicorn"):
-    sys.modules.setdefault(mod, types.ModuleType(mod))
+    try:
+        spec = importlib.util.find_spec(mod)
+    except ValueError:
+        spec = None
+    if spec is None:
+        sys.modules.setdefault(mod, types.ModuleType(mod))
 
 @pytest.fixture
 def dummy_image():
@@ -42,9 +49,14 @@ def pytest_runtest_setup(item):
     """Skip tests marked with 'onnx' if optional deps aren't installed."""
     if "onnx" in item.keywords:
         import importlib.util
-        if (
-            importlib.util.find_spec("onnxruntime") is None
-            or importlib.util.find_spec("fastapi") is None
-        ):
+        try:
+            ort_spec = importlib.util.find_spec("onnxruntime")
+        except ValueError:
+            ort_spec = None
+        try:
+            fastapi_spec = importlib.util.find_spec("fastapi")
+        except ValueError:
+            fastapi_spec = None
+        if ort_spec is None or fastapi_spec is None:
             pytest.skip("Skipping ONNX tests; optional extra not installed")
 

--- a/tests/test_face_api.py
+++ b/tests/test_face_api.py
@@ -1,0 +1,41 @@
+import numpy as np
+from fastapi.testclient import TestClient
+
+from apps.face_api.main import app, face_model, utils
+
+client = TestClient(app)
+
+
+def test_compare_faces_ok(monkeypatch):
+    emb_a = np.array([1.0, 0.0, 0.0])
+    emb_b = np.array([1.0, 0.0, 0.0])
+
+    def fake_get_embedding(data):
+        return emb_a if data == b"a" else emb_b
+
+    monkeypatch.setattr(face_model, "get_embedding", fake_get_embedding)
+
+    resp = client.post(
+        "/v1/image/compare_faces",
+        files={
+            "image_a": ("a.png", b"a", "image/png"),
+            "image_b": ("b.png", b"b", "image/png"),
+        },
+    )
+    assert resp.status_code == 200
+    expected = utils.cosine_similarity(emb_a, emb_b)
+    assert abs(resp.json()["similarity"] - expected) < 1e-6
+
+
+def test_compare_faces_no_face(monkeypatch):
+    def fake_get_embedding(data):
+        return None
+
+    monkeypatch.setattr(face_model, "get_embedding", fake_get_embedding)
+
+    resp = client.post(
+        "/v1/image/compare_faces",
+        files={"image_a": ("a.png", b"a", "image/png"), "image_b": ("b.png", b"b", "image/png")},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"] == "face_not_detected"

--- a/tests/test_node_compare_faces.py
+++ b/tests/test_node_compare_faces.py
@@ -1,0 +1,36 @@
+import types
+
+from nodes.compare_faces import CompareFacesNode
+import nodes.compare_faces as cf
+
+
+def test_node_success(monkeypatch, dummy_image):
+    node = CompareFacesNode()
+
+    monkeypatch.setattr(cf, "tensor_to_pil", lambda img: dummy_image)
+
+    resp = types.SimpleNamespace()
+    resp.status_code = 200
+    resp.json = lambda: {"similarity": 0.8}
+
+    monkeypatch.setattr(cf.requests, "post", lambda *a, **k: resp)
+
+    sim, same = node.compare(dummy_image, dummy_image, api_url="http://x", threshold=0.72)
+    assert sim == 0.8
+    assert same is True
+
+
+def test_node_error(monkeypatch, dummy_image):
+    node = CompareFacesNode()
+
+    monkeypatch.setattr(cf, "tensor_to_pil", lambda img: dummy_image)
+
+    resp = types.SimpleNamespace()
+    resp.status_code = 422
+    resp.json = lambda: {"error": "face_not_detected"}
+
+    monkeypatch.setattr(cf.requests, "post", lambda *a, **k: resp)
+
+    sim, same = node.compare(dummy_image, dummy_image, api_url="http://x")
+    assert sim == 0.0
+    assert same is False


### PR DESCRIPTION
## Summary
- implement FastAPI server for face similarity queries
- create CompareFacesNode for ComfyUI
- add utilities and Dockerfile
- extend test helpers for optional deps
- add tests for server and node

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773527ef888331b8a7beba2f227770