### PR TITLE
Add face comparison server and node

### DIFF
--- a/apps/face_api/Dockerfile
+++ b/apps/face_api/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . /app
+RUN pip install -r requirements.txt
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "7860"]

--- a/apps/face_api/face_model.py
+++ b/apps/face_api/face_model.py
@@ -1,0 +1,37 @@
+import io
+import os
+from typing import Optional
+
+import numpy as np
+from PIL import Image
+
+try:
+    from insightface.app import FaceAnalysis
+except Exception:  # pragma: no cover - optional heavy dep
+    FaceAnalysis = None  # type: ignore
+
+_model: Optional["FaceAnalysis"] = None
+
+
+def _load_model() -> Optional["FaceAnalysis"]:
+    """Load the InsightFace model if available."""
+    global _model
+    if _model is None and FaceAnalysis is not None:
+        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        _model = FaceAnalysis(name="buffalo_l", providers=providers)
+        _model.prepare(ctx_id=0, det_size=(640, 640))
+    return _model
+
+
+def get_embedding(image_bytes: bytes) -> Optional[np.ndarray]:
+    """Return face embedding for the first detected face, or None."""
+    model = _load_model()
+    if model is None:
+        return None
+
+    img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    img_np = np.asarray(img)
+    faces = model.get(img_np)
+    if not faces:
+        return None
+    return faces[0].embedding

--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import JSONResponse
+
+from .face_model import get_embedding
+from .utils import cosine_similarity
+
+app = FastAPI()
+
+
+@app.post("/v1/image/compare_faces")
+async def compare_faces(image_a: UploadFile = File(...), image_b: UploadFile = File(...)):
+    data_a = await image_a.read()
+    data_b = await image_b.read()
+
+    emb_a = get_embedding(data_a)
+    emb_b = get_embedding(data_b)
+
+    if emb_a is None or emb_b is None:
+        return JSONResponse(status_code=422, content={"error": "face_not_detected"})
+
+    similarity = cosine_similarity(emb_a, emb_b)
+    return {"similarity": round(float(similarity), 4)}
+
+
+def main():
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "7860")))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/face_api/requirements.txt
+++ b/apps/face_api/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.95
+uvicorn>=0.22
+insightface
+numpy>=1.23
+pillow>=9.0

--- a/apps/face_api/utils.py
+++ b/apps/face_api/utils.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+
+def cosine_similarity(vec1: np.ndarray, vec2: np.ndarray) -> float:
+    """Return cosine similarity between two vectors."""
+    return float(np.dot(vec1, vec2) / (np.linalg.norm(vec1) * np.linalg.norm(vec2)))

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -1,0 +1,16 @@
+import os
+
+if os.getenv("UNIT_TEST_MODE") != "1":
+    from .compare_faces import CompareFacesNode
+
+    NODE_CLASS_MAPPINGS = {
+        "CompareFacesNode": CompareFacesNode,
+    }
+
+    NODE_DISPLAY_NAME_MAPPINGS = {
+        "CompareFacesNode": "Compare Faces",
+    }
+else:
+    NODE_CLASS_MAPPINGS = {}
+    NODE_DISPLAY_NAME_MAPPINGS = {}
+

--- a/nodes/compare_faces.py
+++ b/nodes/compare_faces.py
@@ -1,0 +1,57 @@
+import os
+import tempfile
+import requests
+from PIL import Image
+from typing import Tuple
+
+from custom_nodes.image_utils import tensor_to_pil
+
+
+class CompareFacesNode:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image_a": ("IMAGE",),
+                "image_b": ("IMAGE",),
+                "api_url": ("STRING", {"default": "http://127.0.0.1:7860/v1/image/compare_faces"}),
+                "threshold": ("FLOAT", {"default": 0.72, "min": 0.0, "max": 1.0}),
+            }
+        }
+
+    RETURN_TYPES = ("FLOAT", "BOOLEAN")
+    RETURN_NAMES = ("similarity_score", "same_person")
+    FUNCTION = "compare"
+    CATEGORY = "AI/Face"
+
+    def compare(self, image_a, image_b, api_url: str, threshold: float = 0.72) -> Tuple[float, bool]:
+        tmp_paths = []
+        try:
+            pil_a = tensor_to_pil(image_a)
+            pil_b = tensor_to_pil(image_b)
+            f_a = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+            pil_a.save(f_a.name, format="PNG")
+            f_a.close()
+            tmp_paths.append(f_a.name)
+            f_b = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+            pil_b.save(f_b.name, format="PNG")
+            f_b.close()
+            tmp_paths.append(f_b.name)
+
+            with open(f_a.name, "rb") as fa, open(f_b.name, "rb") as fb:
+                files = {"image_a": fa, "image_b": fb}
+                resp = requests.post(api_url, files=files, timeout=30)
+
+            if resp.status_code != 200:
+                return 0.0, False
+            data = resp.json()
+            sim = float(data.get("similarity", 0.0))
+            return sim, sim >= threshold
+        except Exception:
+            return 0.0, False
+        finally:
+            for p in tmp_paths:
+                try:
+                    os.remove(p)
+                except Exception:
+                    pass

--- a/tests/test_face_api.py
+++ b/tests/test_face_api.py
@@ -1,0 +1,46 @@
+import pytest
+
+pytestmark = pytest.mark.onnx
+
+try:
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - optional
+    TestClient = None
+
+if TestClient is None:
+    pytest.skip("fastapi not available", allow_module_level=True)
+else:
+    from apps.face_api.main import app
+    import apps.face_api.face_model as face_model
+    from apps.face_api.utils import cosine_similarity
+    import numpy as np
+
+
+def _client(monkeypatch):
+    if TestClient is None:
+        pytest.skip("fastapi not available")
+    return TestClient(app)
+
+
+def test_compare_faces_success(monkeypatch):
+    client = _client(monkeypatch)
+    v1 = np.array([1.0, 0.0, 0.0])
+    v2 = np.array([1.0, 0.0, 0.0])
+    monkeypatch.setattr(face_model, "get_embedding", lambda b: v1 if b == b"a" else v2)
+    resp = client.post(
+        "/v1/image/compare_faces",
+        files={"image_a": ("a.png", b"a", "image/png"), "image_b": ("b.png", b"b", "image/png")},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["similarity"] == pytest.approx(1.0)
+
+
+def test_compare_faces_no_face(monkeypatch):
+    client = _client(monkeypatch)
+    monkeypatch.setattr(face_model, "get_embedding", lambda b: None)
+    resp = client.post(
+        "/v1/image/compare_faces",
+        files={"image_a": ("a.png", b"a", "image/png"), "image_b": ("b.png", b"b", "image/png")},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"] == "face_not_detected"

--- a/tests/test_node_compare_faces.py
+++ b/tests/test_node_compare_faces.py
@@ -1,0 +1,37 @@
+from PIL import Image
+import pytest
+
+from nodes.compare_faces import CompareFacesNode
+
+
+def test_node_compare_faces_success(monkeypatch):
+    node = CompareFacesNode()
+
+    # Stub tensor_to_pil to avoid torch dependency
+    from nodes import compare_faces as cf
+    monkeypatch.setattr(cf, "tensor_to_pil", lambda img: Image.new("RGB", (1,1)))
+
+    class DummyResp:
+        status_code = 200
+        def json(self):
+            return {"similarity": 0.8}
+    monkeypatch.setattr(cf.requests, "post", lambda url, files=None, timeout=30: DummyResp())
+
+    sim, same = node.compare("a", "b", api_url="http://x", threshold=0.72)
+    assert sim == 0.8
+    assert same is True
+
+
+def test_node_compare_faces_failure(monkeypatch):
+    node = CompareFacesNode()
+    from nodes import compare_faces as cf
+    monkeypatch.setattr(cf, "tensor_to_pil", lambda img: Image.new("RGB", (1,1)))
+    class DummyResp:
+        status_code = 422
+        def json(self):
+            return {"error": "face_not_detected"}
+    monkeypatch.setattr(cf.requests, "post", lambda *a, **k: DummyResp())
+
+    sim, same = node.compare("a", "b", api_url="http://x", threshold=0.72)
+    assert sim == 0.0
+    assert same is False


### PR DESCRIPTION
## Summary
- implement new FastAPI app for face comparison under `apps/face_api`
- create CompareFacesNode for ComfyUI usage
- add unit tests for API and node

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773527ef888331b8a7beba2f227770