### PR TITLE
Improve documentation for nodes and servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ This project exposes a lightweight HTTP API for text or vision models and can us
 
 ## **✨ Features**  
 
-- ✅ **Text & Vision-Based LLM Inference** – Process **both images and text** in ComfyUI.  
-- ✅ **Multimodal Model Support** – Works with **Qwen-VL**, **Llava**, and more.  
-- ✅ **Stable & Resilient** – Offloads heavy inference to an optional external server.
-- ✅ **Optimized Image Handling** – Minimizes memory usage with **controlled tokenization**.
-- ☁️ **Decoupled Architecture** – The node communicates with any OpenAI-compatible HTTP endpoint so your LLM can run remotely.
+ComfyAI ships with a set of custom nodes for ComfyUI:
+
+- **VLLMTextQuery**, **VLLMImageQuery** and **VLLMDualImageQuery** – send text, one image or two images to your favourite LLM endpoint.
+- **CompareFacesNode** – compare two face images using the optional face API.
+- **ConditionalSaveImage** – only save results when a connected boolean evaluates to `True`.
+
+All nodes communicate with any OpenAI‑compatible HTTP endpoint. Heavy model inference can run remotely, including via the lightweight ONNX server that comes with this repository.
+See [nodes/README.md](nodes/README.md) for a full list of inputs and outputs.
 
 ---
 
@@ -98,7 +101,7 @@ The **Vision LLM** can compare **two images** and **output a True/False result**
 📝 **Example Prompt:**  
 > *"Answer yes or no, are the following two images similarly themed?"*  
 
-💡 **Tip:** This library includes a **`ConditionalSave` node**, which allows saving an image **only if a boolean condition is met**.  
+💡 **Tip:** This library includes a **`ConditionalSaveImage` node**, which saves images **only when a connected boolean input is `True`**.
 
 ---
 
@@ -158,6 +161,8 @@ comfyai-onnx-server  # or: python -m apps.onnx_server
 
 The client node accepts any OpenAI compatible endpoint URL, so you can point it
 to this server, Ollama, or the official OpenAI API.
+
+See [apps/README.md](apps/README.md) for details on the bundled servers.
 
 ---
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,32 @@
+# Embedded Servers
+
+The `apps/` directory contains optional HTTP services that expose lightweight APIs used by some nodes.
+
+## ONNX Chat Completion Server
+
+`onnx_server.py` starts a minimal OpenAI compatible endpoint. It can run a toy ONNX model or fall back to very simple rules if no model is provided. Use it when you need a local endpoint for the query nodes.
+
+Run it with:
+
+```bash
+python -m apps.onnx_server
+```
+
+Set `ONNX_MODEL_PATH` to point at an ONNX model file if you have one. The server listens on port `8000` by default.
+
+## Face Comparison API
+
+`face_api/` hosts a small FastAPI application that compares two face images. It relies on InsightFace and ONNX Runtime to extract embeddings.
+
+Launch it using:
+
+```bash
+uvicorn apps.face_api.main:app --host 0.0.0.0 --port 7860
+```
+
+Several environment variables let you tune which provider or model is used:
+
+- `FACE_MODEL_PROVIDERS` – comma separated list of ONNX providers (default: `CUDAExecutionProvider,CPUExecutionProvider`)
+- `FACE_MODEL_NAME` – name of the InsightFace model (default: `buffalo_l`)
+
+The `CompareFacesNode` sends images to this API and receives a similarity score.

--- a/nodes/README.md
+++ b/nodes/README.md
@@ -1,0 +1,13 @@
+# Available Nodes
+
+This folder contains all custom nodes shipped with ComfyAI. They are automatically registered when the environment variable `UNIT_TEST_MODE` is not set.
+
+| Node | Description |
+|------|-------------|
+| `VLLMTextQuery` | Send a text prompt to an OpenAI compatible endpoint and return the raw text reply together with a boolean interpretation. |
+| `VLLMImageQuery` | Like `VLLMTextQuery` but also sends one image. |
+| `VLLMDualImageQuery` | Sends two images along with the prompt, useful for comparison tasks. |
+| `ConditionalSaveImage` | Saves incoming images to the ComfyUI output directory only when a boolean input is `True`. |
+| `CompareFacesNode` | Uses the face comparison API in `apps/face_api` to determine whether two images depict the same person. |
+
+Every node exposes standard `INPUT_TYPES` and `RETURN_TYPES` as expected by ComfyUI.


### PR DESCRIPTION
## Summary
- document available nodes and apps
- highlight node-based features on the front page
- fix reference to `ConditionalSaveImage` node

## Testing
- `pytest tests -q`
- `pytest integration_tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68775b1d33108331ad5d0003171da889