### PR TITLE
Refactor ONNX chat server

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Install the optional extra and run the server:
 
 ```bash
 pip install comfyai[onnx]
-comfyai-onnx-server  # or: python -m apps.onnx_server
+comfyai-onnx-server  # or: python -m apps.onnx_chat.main
 ```
 
 The client node accepts any OpenAI compatible endpoint URL, so you can point it
@@ -185,6 +185,7 @@ pip install comfyai[onnx]
 
 - `COMFYAI_ENDPOINT` – base URL for API calls (default: `https://api.openai.com/v1`)
 - `COMFYAI_ONNX_PORT` – local ONNX server port (default: `8000`)
+- `ONNX_LOG_LEVEL` – uvicorn log level for the chat server (default: `info`)
 - `FACE_MODEL_PROVIDERS` – comma-separated ONNX providers (default: `CUDAExecutionProvider,CPUExecutionProvider`)
 - `FACE_MODEL_NAME` – InsightFace model name (default: `buffalo_l`)
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -4,15 +4,22 @@ The `apps/` directory contains optional HTTP services that expose lightweight AP
 
 ## ONNX Chat Completion Server
 
-`onnx_server.py` starts a minimal OpenAI compatible endpoint. It can run a toy ONNX model or fall back to very simple rules if no model is provided. Use it when you need a local endpoint for the query nodes.
+`onnx_chat/` contains a minimal OpenAI compatible endpoint. It can run a toy ONNX model or fall back to very simple rules if no model is provided. Use it when you need a local endpoint for the query nodes.
 
 Run it with:
 
 ```bash
-python -m apps.onnx_server
+python -m apps.onnx_chat.main
 ```
 
-Set `ONNX_MODEL_PATH` to point at an ONNX model file if you have one. The server listens on port `8000` by default.
+Set `ONNX_MODEL_PATH` to point at an ONNX model file if you have one. The server listens on port `8000` by default and honours `COMFYAI_ONNX_PORT` and `ONNX_LOG_LEVEL`.
+
+Build a container using the supplied Dockerfile if preferred:
+
+```bash
+docker build -t onnx-chat apps/onnx_chat
+docker run -p 8000:8000 onnx-chat
+```
 
 ## Face Comparison API
 
@@ -30,6 +37,13 @@ Launch it using:
 
 ```bash
 uvicorn apps.face_api.main:app --host 0.0.0.0 --port 7860
+```
+
+Or build and run the Docker image:
+
+```bash
+docker build -t face-api apps/face_api
+docker run -p 7860:7860 face-api
 ```
 
 Several environment variables let you tune which provider or model is used:

--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -7,12 +7,21 @@ import io
 from typing import Optional
 import numpy as np
 from PIL import Image
-import onnxruntime as ort
-from huggingface_hub import hf_hub_download
+try:
+    import onnxruntime as ort
+except Exception:  # pragma: no cover - optional dependency
+    ort = None
+try:
+    from huggingface_hub import hf_hub_download
+except Exception:  # pragma: no cover - optional dependency
+    hf_hub_download = None
 import shutil
 
 # Requires: pip install dghs-imgutils
-from imgutils.detect.face import detect_faces
+try:
+    from imgutils.detect.face import detect_faces
+except Exception:  # pragma: no cover - optional dependency
+    detect_faces = None
 
 # Logging configuration
 logger = logging.getLogger(__name__)
@@ -63,8 +72,8 @@ DEFAULT_THRESHOLD = float(os.getenv("DETECTOR_THRESHOLD",
 # Model loader class for modularity
 class ModelLoader:
     def __init__(self):
-        self._detector: Optional[ort.InferenceSession] = None
-        self._embedder: Optional[ort.InferenceSession] = None
+        self._detector: Optional[object] = None
+        self._embedder: Optional[object] = None
 
     def _get_providers(self):
         providers = []
@@ -88,7 +97,7 @@ class ModelLoader:
                 raise
         return local_path
 
-    def load_detector(self) -> ort.InferenceSession:
+    def load_detector(self):
         if self._detector is None:
             try:
                 cache_dir = os.path.expanduser("~/.cache/face_api/detector")
@@ -101,7 +110,7 @@ class ModelLoader:
                 raise
         return self._detector
 
-    def load_embedder(self) -> ort.InferenceSession:
+    def load_embedder(self):
         if self._embedder is None:
             try:
                 cache_dir = os.path.expanduser("~/.cache/face_api/embedder")

--- a/apps/onnx_chat/Dockerfile
+++ b/apps/onnx_chat/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/onnx_chat/main.py
+++ b/apps/onnx_chat/main.py
@@ -72,7 +72,9 @@ async def chat(request: Request):
 def main():
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "8000")))
+    port = int(os.environ.get("COMFYAI_ONNX_PORT", "8000"))
+    log_level = os.environ.get("ONNX_LOG_LEVEL", "info")
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level=log_level)
 
 
 if __name__ == "__main__":

--- a/apps/onnx_chat/requirements.txt
+++ b/apps/onnx_chat/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+onnxruntime
+pydantic

--- a/integration_tests/test_server_api.py
+++ b/integration_tests/test_server_api.py
@@ -11,8 +11,8 @@ except Exception:  # pragma: no cover - optional
 if TestClient is None:
     pytest.skip("fastapi not available", allow_module_level=True)
 else:
-    from apps.onnx_server import app
-    import apps.onnx_server as onnx_server
+    from apps.onnx_chat.main import app
+    import apps.onnx_chat.main as onnx_server
 
 
 def _client(monkeypatch):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ numpy = "^1.23"
 requests = "^2.28"
 
 [project.scripts]
-comfyai-onnx-server = "apps.onnx_server:main"
+comfyai-onnx-server = "apps.onnx_chat.main:main"


### PR DESCRIPTION
## Summary
- move ONNX server into `apps/onnx_chat`
- expose a Dockerfile and requirements for the ONNX server
- add uvicorn-based entrypoint and script path updates
- document ONNX server and face API usage and container builds
- make face API imports optional for tests

## Testing
- `pytest -q tests`
- `pytest -q integration_tests`


------
https://chatgpt.com/codex/tasks/task_e_6877915fe27083319951ad25b35e1355