### PR TITLE
Refactor ONNX chat server

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Install the optional extra and run the server:
 
 ```bash
 pip install comfyai[onnx]
-comfyai-onnx-server  # or: python -m apps.onnx_server
+comfyai-onnx-server  # or: uvicorn apps.onnx_chat.main:app --host 0.0.0.0 --port 8000
 ```
 
 The client node accepts any OpenAI compatible endpoint URL, so you can point it

--- a/apps/README.md
+++ b/apps/README.md
@@ -4,15 +4,16 @@ The `apps/` directory contains optional HTTP services that expose lightweight AP
 
 ## ONNX Chat Completion Server
 
-`onnx_server.py` starts a minimal OpenAI compatible endpoint. It can run a toy ONNX model or fall back to very simple rules if no model is provided. Use it when you need a local endpoint for the query nodes.
+`onnx_chat/` hosts a minimal OpenAI compatible endpoint. It runs a toy ONNX model if available and otherwise falls back to a couple of simple rules.
 
 Run it with:
 
 ```bash
-python -m apps.onnx_server
+uvicorn apps.onnx_chat.main:app --host 0.0.0.0 --port 8000
 ```
 
 Set `ONNX_MODEL_PATH` to point at an ONNX model file if you have one. The server listens on port `8000` by default.
+A `Dockerfile` is provided for convenience if you prefer containerised runs.
 
 ## Face Comparison API
 

--- a/apps/onnx_chat/Dockerfile
+++ b/apps/onnx_chat/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/onnx_chat/main.py
+++ b/apps/onnx_chat/main.py
@@ -1,13 +1,14 @@
-import os
+"""Minimal OpenAI-compatible chat server using FastAPI."""
+
 from typing import List, Dict, Any
+import os
 
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError
 
 try:
-    import onnxruntime as ort
-except Exception:  # pragma: no cover - optional dependency
+    import onnxruntime as ort  # optional
+except Exception:  # pragma: no cover
     ort = None
 
 app = FastAPI()
@@ -22,15 +23,16 @@ MODEL_PATH = os.environ.get("ONNX_MODEL_PATH")
 
 
 def load_session():
+    """Load the ONNX model on first use if available."""
     global session
     if session is None and ort and MODEL_PATH and os.path.exists(MODEL_PATH):
         session = ort.InferenceSession(MODEL_PATH)
 
 
 def classify(text: str) -> str:
+    """Return a simple classification using the model or a rule based fallback."""
     load_session()
     if session is None:
-        # Fallback simple rule when ONNX model is unavailable
         return "positive" if "good" in text.lower() else "negative"
     inputs = {session.get_inputs()[0].name: [[ord(c) for c in text]]}
     outputs = session.run(None, inputs)[0]
@@ -41,13 +43,9 @@ def classify(text: str) -> str:
 async def chat(request: Request):
     try:
         data = await request.json()
-    except Exception:
-        raise HTTPException(status_code=400, detail="Invalid JSON")
-
-    try:
         req = ChatRequest(**data)
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=e.errors())
+    except Exception as e:  # JSON error or validation
+        raise HTTPException(status_code=400, detail=str(e))
 
     text = ""
     if req.messages:
@@ -58,6 +56,7 @@ async def chat(request: Request):
                     text += part.get("text", "")
         else:
             text = str(content)
+
     result = classify(text)
     return {
         "id": "cmpl-001",
@@ -69,11 +68,12 @@ async def chat(request: Request):
     }
 
 
-def main():
+def main():  # pragma: no cover
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "8000")))
+    log_level = os.getenv("ONNX_CHAT_LOG_LEVEL", "info")
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "8000")), log_level=log_level)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/apps/onnx_chat/requirements.txt
+++ b/apps/onnx_chat/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pydantic
+onnxruntime

--- a/integration_tests/test_server_api.py
+++ b/integration_tests/test_server_api.py
@@ -11,8 +11,8 @@ except Exception:  # pragma: no cover - optional
 if TestClient is None:
     pytest.skip("fastapi not available", allow_module_level=True)
 else:
-    from apps.onnx_server import app
-    import apps.onnx_server as onnx_server
+    from apps.onnx_chat.main import app
+    import apps.onnx_chat.main as onnx_server
 
 
 def _client(monkeypatch):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ numpy = "^1.23"
 requests = "^2.28"
 
 [project.scripts]
-comfyai-onnx-server = "apps.onnx_server:main"
+comfyai-onnx-server = "apps.onnx_chat.main:main"


### PR DESCRIPTION
## Summary
- move ONNX chat API to `apps/onnx_chat/`
- run it via uvicorn like the face API
- document both servers with clear instructions
- provide a Dockerfile for the chat server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877915fe27083319951ad25b35e1355