### PR TITLE
Add face API presets and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,28 @@ uvicorn apps.face_api.main:app --host 0.0.0.0 --port 7860
 
 Set the environment variables above to tweak model selection or provider order.
 
+#### Preset Examples
+
+```bash
+# Use built-in photo preset
+PRESET=photo \
+PRELOAD_MODELS=true \
+FACE_API_LOG_LEVEL=DEBUG \
+uvicorn apps.face_api.main:app --host 0.0.0.0 --port 7860
+```
+
+```bash
+# Custom models
+DETECTOR_MODEL=deepghs/real_face_detection \
+DETECTOR_FILE=face_detect_v1.4_s/model.onnx \
+EMBEDDER_MODEL_PATH=openailab/onnx-arcface-resnet100-ms1m \
+EMBEDDER_FILE=model.onnx \
+DETECTOR_THRESHOLD=0.446 \
+PRELOAD_MODELS=true \
+FACE_API_LOG_LEVEL=DEBUG \
+uvicorn apps.face_api.main:app --host 0.0.0.0 --port 7860
+```
+
 ### Example Usage
 
 ```python

--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -11,6 +11,31 @@ import onnxruntime as ort
 from huggingface_hub import hf_hub_download
 import shutil
 
+# Built-in presets for zero-config use
+PRESETS = {
+    "photo": {
+        "detector_repo": "deepghs/real_face_detection",
+        "detector_file": "face_detect_v1.4_s/model.onnx",
+        "embedder_repo": "openailab/onnx-arcface-resnet100-ms1m",
+        "embedder_file": "model.onnx",
+        "threshold": 0.446,
+    },
+    "anime": {
+        "detector_repo": "deepghs/anime_face_detection",
+        "detector_file": "face_detect_v1.4_s/model.onnx",
+        "embedder_repo": "Xenova/clip-vit-base-patch32",
+        "embedder_file": "onnx/vision_model.onnx",
+        "threshold": 0.307,
+    },
+    "cg": {
+        "detector_repo": "deepghs/real_face_detection",
+        "detector_file": "face_detect_v1.4_n/model.onnx",
+        "embedder_repo": "Xenova/clip-vit-base-patch32",
+        "embedder_file": "onnx/vision_model.onnx",
+        "threshold": 0.278,
+    },
+}
+
 # Requires: pip install dghs-imgutils
 from imgutils.detect.face import detect_faces
 
@@ -42,6 +67,7 @@ DEFAULT_THRESHOLD_MAP = {
 DEFAULT_LEVEL = os.getenv("DETECTOR_LEVEL", "s")
 DEFAULT_VERSION = os.getenv("DETECTOR_VERSION", "v1.4")
 
+
 # Enforce mandatory environment variables
 def get_env_var(name: str) -> str:
     value = os.getenv(name)
@@ -50,15 +76,26 @@ def get_env_var(name: str) -> str:
         raise EnvironmentError(f"Mandatory environment variable '{name}' is not set.")
     return value
 
-DETECTOR_MODEL = get_env_var("DETECTOR_MODEL")
-DETECTOR_FILE = get_env_var("DETECTOR_FILE")
-EMBEDDER_MODEL_PATH = get_env_var("EMBEDDER_MODEL_PATH")
-EMBEDDER_FILE = get_env_var("EMBEDDER_FILE")
 
-# Optional overrides
-DEFAULT_THRESHOLD = float(os.getenv("DETECTOR_THRESHOLD",
-    DEFAULT_THRESHOLD_MAP.get(DETECTOR_FILE, 0.5)
-))
+preset = os.getenv("PRESET", "").lower()
+if preset in PRESETS:
+    cfg = PRESETS[preset]
+    DETECTOR_MODEL = cfg["detector_repo"]
+    DETECTOR_FILE = cfg["detector_file"]
+    EMBEDDER_MODEL_PATH = cfg["embedder_repo"]
+    EMBEDDER_FILE = cfg["embedder_file"]
+    DEFAULT_THRESHOLD = cfg["threshold"]
+else:
+    DETECTOR_MODEL = get_env_var("DETECTOR_MODEL")
+    DETECTOR_FILE = get_env_var("DETECTOR_FILE")
+    EMBEDDER_MODEL_PATH = get_env_var("EMBEDDER_MODEL_PATH")
+    EMBEDDER_FILE = get_env_var("EMBEDDER_FILE")
+    DEFAULT_THRESHOLD = float(
+        os.getenv(
+            "DETECTOR_THRESHOLD",
+            DEFAULT_THRESHOLD_MAP.get(DETECTOR_FILE, 0.5),
+        )
+    )
 
 # Model loader class for modularity
 class ModelLoader:


### PR DESCRIPTION
## Summary
- add preset configuration to the face API
- expose PRESET variable that selects bundled models
- document preset examples in README

## Testing
- `pip install -r requirements-dev.txt`
- `pip install fastapi uvicorn httpx dghs-imgutils onnxruntime==1.17.3`
- `pytest -q` *(fails: ImportError from onnxruntime)*

------
https://chatgpt.com/codex/tasks/task_e_6877918eb9a8833194010c7465b10d24