### PR TITLE
Refactor ONNX chat server

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,22 @@ Install the optional extra and run the server:
 
 ```bash
 pip install comfyai[onnx]
-comfyai-onnx-server  # or: python -m apps.onnx_server
+comfyai-onnx-server  # or: python -m apps.onnx_chat.main
 ```
 
 The client node accepts any OpenAI compatible endpoint URL, so you can point it
 to this server, Ollama, or the official OpenAI API.
 
 See [apps/README.md](apps/README.md) for details on the bundled servers.
+
+To build a container:
+
+```bash
+docker build -t onnx-chat \
+  --build-arg DETECTOR_MODEL=deepghs/real_face_detection \
+  --build-arg EMBEDDER_MODEL=Xenova/clip-vit-base-patch32 \
+  apps/onnx_chat
+```
 
 ---
 
@@ -185,6 +194,13 @@ pip install comfyai[onnx]
 
 - `COMFYAI_ENDPOINT` – base URL for API calls (default: `https://api.openai.com/v1`)
 - `COMFYAI_ONNX_PORT` – local ONNX server port (default: `8000`)
+- `LOG_LEVEL` – root log level for both servers (default: `INFO`)
+- `ONNX_MODEL_PATH` – optional path to an ONNX model for the chat server
+- `DETECTOR_MODEL` – face detector repo (required for face API)
+- `DETECTOR_FILE` – file name within the detector repo
+- `EMBEDDER_MODEL_PATH` – embedder repo for the face API
+- `EMBEDDER_FILE` – file name within the embedder repo
+- `THRESHOLD` – override similarity threshold (defaults per model)
 - `FACE_MODEL_PROVIDERS` – comma-separated ONNX providers (default: `CUDAExecutionProvider,CPUExecutionProvider`)
 - `FACE_MODEL_NAME` – InsightFace model name (default: `buffalo_l`)
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -4,15 +4,36 @@ The `apps/` directory contains optional HTTP services that expose lightweight AP
 
 ## ONNX Chat Completion Server
 
-`onnx_server.py` starts a minimal OpenAI compatible endpoint. It can run a toy ONNX model or fall back to very simple rules if no model is provided. Use it when you need a local endpoint for the query nodes.
+`onnx_chat/` contains a minimal OpenAI compatible endpoint. It can run a toy ONNX model or fall back to very simple rules if no model is provided. Use it when you need a local endpoint for the query nodes.
 
 Run it with:
 
 ```bash
-python -m apps.onnx_server
+python -m apps.onnx_chat.main
 ```
 
-Set `ONNX_MODEL_PATH` to point at an ONNX model file if you have one. The server listens on port `8000` by default.
+Set `ONNX_MODEL_PATH` to point at an ONNX model file if you have one. The server listens on port `8000` by default and honours `COMFYAI_ONNX_PORT` and `LOG_LEVEL`.
+
+Example overriding models and threshold:
+
+```bash
+DETECTOR_MODEL=deepghs/real_face_detection \
+EMBEDDER_MODEL=Xenova/clip-vit-base-patch32 \
+THRESHOLD=0.65 \
+uvicorn apps.onnx_chat.main:app --reload
+```
+
+`THRESHOLD` defaults per preset but can always be overridden.
+
+Build a container using the supplied Dockerfile if preferred:
+
+```bash
+docker build -t onnx-chat \
+  --build-arg DETECTOR_MODEL=deepghs/real_face_detection \
+  --build-arg EMBEDDER_MODEL=Xenova/clip-vit-base-patch32 \
+  apps/onnx_chat
+docker run -p 8000:8000 onnx-chat
+```
 
 ## Face Comparison API
 
@@ -30,6 +51,13 @@ Launch it using:
 
 ```bash
 uvicorn apps.face_api.main:app --host 0.0.0.0 --port 7860
+```
+
+Or build and run the Docker image:
+
+```bash
+docker build -t face-api apps/face_api
+docker run -p 7860:7860 face-api
 ```
 
 Several environment variables let you tune which provider or model is used:

--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -7,12 +7,21 @@ import io
 from typing import Optional
 import numpy as np
 from PIL import Image
-import onnxruntime as ort
-from huggingface_hub import hf_hub_download
+try:
+    import onnxruntime as ort
+except Exception:  # pragma: no cover - optional dependency
+    ort = None
+try:
+    from huggingface_hub import hf_hub_download
+except Exception:  # pragma: no cover - optional dependency
+    hf_hub_download = None
 import shutil
 
 # Requires: pip install dghs-imgutils
-from imgutils.detect.face import detect_faces
+try:
+    from imgutils.detect.face import detect_faces
+except Exception:  # pragma: no cover - optional dependency
+    detect_faces = None
 
 # Logging configuration
 logger = logging.getLogger(__name__)
@@ -63,8 +72,8 @@ DEFAULT_THRESHOLD = float(os.getenv("DETECTOR_THRESHOLD",
 # Model loader class for modularity
 class ModelLoader:
     def __init__(self):
-        self._detector: Optional[ort.InferenceSession] = None
-        self._embedder: Optional[ort.InferenceSession] = None
+        self._detector: Optional[object] = None
+        self._embedder: Optional[object] = None
 
     def _get_providers(self):
         providers = []
@@ -88,7 +97,7 @@ class ModelLoader:
                 raise
         return local_path
 
-    def load_detector(self) -> ort.InferenceSession:
+    def load_detector(self):
         if self._detector is None:
             try:
                 cache_dir = os.path.expanduser("~/.cache/face_api/detector")
@@ -101,7 +110,7 @@ class ModelLoader:
                 raise
         return self._detector
 
-    def load_embedder(self) -> ort.InferenceSession:
+    def load_embedder(self):
         if self._embedder is None:
             try:
                 cache_dir = os.path.expanduser("~/.cache/face_api/embedder")

--- a/apps/onnx_chat/Dockerfile
+++ b/apps/onnx_chat/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.10-slim AS builder
+WORKDIR /build
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+FROM python:3.10-slim
+WORKDIR /app
+COPY --from=builder /install /usr/local
+COPY . /app
+
+ARG DETECTOR_MODEL
+ARG EMBEDDER_MODEL
+ARG THRESHOLD=0.5
+ARG ONNX_MODEL_PATH
+ARG COMFYAI_ONNX_PORT=8000
+ARG LOG_LEVEL=info
+
+ENV DETECTOR_MODEL=${DETECTOR_MODEL}
+ENV EMBEDDER_MODEL=${EMBEDDER_MODEL}
+ENV THRESHOLD=${THRESHOLD}
+ENV ONNX_MODEL_PATH=${ONNX_MODEL_PATH}
+ENV COMFYAI_ONNX_PORT=${COMFYAI_ONNX_PORT}
+ENV LOG_LEVEL=${LOG_LEVEL}
+
+CMD ["python", "-m", "apps.onnx_chat.main"]

--- a/apps/onnx_chat/config.py
+++ b/apps/onnx_chat/config.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+import os
+import logging
+
+@dataclass
+class Config:
+    detector_model: str
+    embedder_model: str
+    threshold: float
+    onnx_model_path: str | None
+    port: int
+    log_level: str
+
+
+def _required(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        logging.critical(f"Missing required environment variable: {name}")
+        raise EnvironmentError(f"Missing required environment variable: {name}")
+    return value
+
+
+def load_config() -> Config:
+    detector_model = _required("DETECTOR_MODEL")
+    embedder_model = _required("EMBEDDER_MODEL")
+    threshold = float(os.getenv("THRESHOLD", "0.5"))
+    onnx_model_path = os.getenv("ONNX_MODEL_PATH")
+    port = int(os.getenv("COMFYAI_ONNX_PORT", "8000"))
+    log_level = os.getenv("LOG_LEVEL", "INFO")
+    return Config(
+        detector_model=detector_model,
+        embedder_model=embedder_model,
+        threshold=threshold,
+        onnx_model_path=onnx_model_path,
+        port=port,
+        log_level=log_level,
+    )

--- a/apps/onnx_chat/main.py
+++ b/apps/onnx_chat/main.py
@@ -1,9 +1,11 @@
 import os
+import logging
 from typing import List, Dict, Any
 
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError
+
+from .config import load_config
 
 try:
     import onnxruntime as ort
@@ -12,13 +14,23 @@ except Exception:  # pragma: no cover - optional dependency
 
 app = FastAPI()
 
+config = load_config()
+
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+logging.getLogger().addHandler(handler)
+root_level = getattr(logging, config.log_level.upper(), logging.INFO)
+logging.getLogger().setLevel(root_level)
+handler.setLevel(root_level)
+
 class ChatRequest(BaseModel):
     model: str
     messages: List[Dict[str, Any]]
     max_tokens: int | None = None
 
 session = None
-MODEL_PATH = os.environ.get("ONNX_MODEL_PATH")
+MODEL_PATH = config.onnx_model_path
+MODEL_NAME = os.path.basename(MODEL_PATH) if MODEL_PATH else "rules"
 
 
 def load_session():
@@ -69,10 +81,29 @@ async def chat(request: Request):
     }
 
 
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    return {"status": "ok", "model": MODEL_NAME}
+
+
 def main():
+    import argparse
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "8000")))
+    parser = argparse.ArgumentParser(description="ONNX Chat Server")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=config.port)
+    parser.add_argument("--reload", action="store_true")
+    parser.add_argument("--log-level", default=config.log_level)
+    args = parser.parse_args()
+
+    uvicorn.run(
+        "apps.onnx_chat.main:app",
+        host=args.host,
+        port=args.port,
+        log_level=args.log_level.lower(),
+        reload=args.reload,
+    )
 
 
 if __name__ == "__main__":

--- a/apps/onnx_chat/requirements.txt
+++ b/apps/onnx_chat/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+onnxruntime
+pydantic

--- a/integration_tests/test_server_api.py
+++ b/integration_tests/test_server_api.py
@@ -11,8 +11,8 @@ except Exception:  # pragma: no cover - optional
 if TestClient is None:
     pytest.skip("fastapi not available", allow_module_level=True)
 else:
-    from apps.onnx_server import app
-    import apps.onnx_server as onnx_server
+    from apps.onnx_chat.main import app
+    import apps.onnx_chat.main as onnx_server
 
 
 def _client(monkeypatch):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ numpy = "^1.23"
 requests = "^2.28"
 
 [project.scripts]
-comfyai-onnx-server = "apps.onnx_server:main"
+comfyai-onnx-server = "apps.onnx_chat.main:main"

--- a/tests/test_face_api.py
+++ b/tests/test_face_api.py
@@ -1,6 +1,10 @@
 import numpy as np
-import importlib, sys
+import importlib, sys, os
 sys.modules.pop("fastapi", None)
+os.environ.setdefault("DETECTOR_MODEL", "dummy")
+os.environ.setdefault("DETECTOR_FILE", "model.onnx")
+os.environ.setdefault("EMBEDDER_MODEL_PATH", "dummy")
+os.environ.setdefault("EMBEDDER_FILE", "model.onnx")
 from fastapi.testclient import TestClient
 from apps.face_api.main import app
 import apps.face_api.face_model as face_model

--- a/tests/test_face_api_smoke.py
+++ b/tests/test_face_api_smoke.py
@@ -1,0 +1,23 @@
+import pytest
+
+try:
+    from fastapi.testclient import TestClient
+    from apps.face_api.main import app
+except Exception:  # pragma: no cover - optional heavy deps
+    TestClient = None
+
+@pytest.mark.skipif(TestClient is None, reason="fastapi not available")
+def test_health_and_compare(monkeypatch):
+    client = TestClient(app)
+
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+    monkeypatch.setattr("apps.face_api.main.get_embedding", lambda x: None)
+    with open("Example01.png", "rb") as f:
+        data = f.read()
+    res = client.post(
+        "/v1/image/compare_faces",
+        files={"image_a": ("a.png", data), "image_b": ("b.png", data)},
+    )
+    assert res.status_code in (200, 422)

--- a/tests/test_node_compare_faces.py
+++ b/tests/test_node_compare_faces.py
@@ -1,6 +1,10 @@
 import numpy as np
-import importlib, sys
+import importlib, sys, os
 sys.modules.pop("fastapi", None)
+os.environ.setdefault("DETECTOR_MODEL", "dummy")
+os.environ.setdefault("DETECTOR_FILE", "model.onnx")
+os.environ.setdefault("EMBEDDER_MODEL_PATH", "dummy")
+os.environ.setdefault("EMBEDDER_FILE", "model.onnx")
 from fastapi.testclient import TestClient
 
 from apps.face_api.main import app


### PR DESCRIPTION
## Summary
- add runtime config loader and environment validation
- expose a `/health` endpoint mirroring face API style
- multi-stage Dockerfile with build args for overriding models
- document all environment variables and container builds
- add smoke-test for face API and adjust tests for mandatory vars

## Testing
- `pytest -q tests`
- `pytest -q integration_tests`


------
https://chatgpt.com/codex/tasks/task_e_6877915fe27083319951ad25b35e1355