### PR TITLE
Refactor ONNX chat server

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Install the optional extra and run the server:
 
 ```bash
 pip install comfyai[onnx]
-comfyai-onnx-server  # or: python -m apps.onnx_server
+comfyai-onnx-server  # or: python -m apps.onnx_chat.main
 ```
 
 The client node accepts any OpenAI compatible endpoint URL, so you can point it
@@ -185,8 +185,15 @@ pip install comfyai[onnx]
 
 - `COMFYAI_ENDPOINT` – base URL for API calls (default: `https://api.openai.com/v1`)
 - `COMFYAI_ONNX_PORT` – local ONNX server port (default: `8000`)
+- `ONNX_LOG_LEVEL` – uvicorn log level for the chat server (default: `info`)
+- `LOG_LEVEL` – format-consistent Python logging level (default: `INFO`)
 - `FACE_MODEL_PROVIDERS` – comma-separated ONNX providers (default: `CUDAExecutionProvider,CPUExecutionProvider`)
 - `FACE_MODEL_NAME` – InsightFace model name (default: `buffalo_l`)
+- `DETECTOR_MODEL` – HuggingFace repository for the face detector
+- `DETECTOR_FILE` – path to the ONNX detector model file within the repo
+- `EMBEDDER_MODEL_PATH` – repository for the embedding model
+- `EMBEDDER_FILE` – path to the embedder ONNX file
+- `DETECTOR_THRESHOLD` – optional threshold override (default per model)
 
 ### Face Comparison API Installation
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -4,15 +4,37 @@ The `apps/` directory contains optional HTTP services that expose lightweight AP
 
 ## ONNX Chat Completion Server
 
-`onnx_server.py` starts a minimal OpenAI compatible endpoint. It can run a toy ONNX model or fall back to very simple rules if no model is provided. Use it when you need a local endpoint for the query nodes.
+`onnx_chat/` contains a minimal OpenAI compatible endpoint. It can run a toy ONNX model or fall back to very simple rules if no model is provided. Use it when you need a local endpoint for the query nodes.
 
 Run it with:
 
 ```bash
-python -m apps.onnx_server
+python -m apps.onnx_chat.main
 ```
 
-Set `ONNX_MODEL_PATH` to point at an ONNX model file if you have one. The server listens on port `8000` by default.
+Set `ONNX_MODEL_PATH` to point at an ONNX model file if you have one. The server listens on port `8000` by default and honours `COMFYAI_ONNX_PORT` and `ONNX_LOG_LEVEL`.
+
+Build a container using the supplied Dockerfile if preferred:
+
+```bash
+docker build -t onnx-chat apps/onnx_chat
+docker run -p 8000:8000 onnx-chat
+```
+
+### Custom environment overrides
+
+Launch with alternative models by setting environment variables before starting
+uvicorn:
+
+```bash
+DETECTOR_MODEL=deepghs/real_face_detection \
+EMBEDDER_MODEL_PATH=Xenova/clip-vit-base-patch32 \
+DETECTOR_THRESHOLD=0.65 \
+uvicorn apps.face_api.main:app --reload
+```
+
+`DETECTOR_THRESHOLD` falls back to a preset per detector model but can always be
+overridden.
 
 ## Face Comparison API
 
@@ -32,9 +54,21 @@ Launch it using:
 uvicorn apps.face_api.main:app --host 0.0.0.0 --port 7860
 ```
 
+Or build and run the Docker image:
+
+```bash
+docker build -t face-api apps/face_api
+docker run -p 7860:7860 face-api
+```
+
 Several environment variables let you tune which provider or model is used:
 
 - `FACE_MODEL_PROVIDERS` – comma separated list of ONNX providers (default: `CUDAExecutionProvider,CPUExecutionProvider`)
 - `FACE_MODEL_NAME` – name of the InsightFace model (default: `buffalo_l`)
+- `DETECTOR_MODEL` – HuggingFace repo containing the detector model
+- `DETECTOR_FILE` – path to the detector ONNX file
+- `EMBEDDER_MODEL_PATH` – repo for the embedding model
+- `EMBEDDER_FILE` – embedding ONNX file
+- `DETECTOR_THRESHOLD` – similarity threshold override
 
 The `CompareFacesNode` sends images to this API and receives a similarity score.

--- a/apps/face_api/Dockerfile
+++ b/apps/face_api/Dockerfile
@@ -1,6 +1,21 @@
+FROM python:3.10-slim AS builder
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --prefix=/install --no-cache-dir -r requirements.txt
+COPY . .
+RUN pip install --prefix=/install --no-cache-dir .
+
 FROM python:3.10-slim
 WORKDIR /app
-COPY . /app
-# Install FastAPI, InsightFace, python-multipart, etc.
-RUN pip install --no-cache-dir -r requirements.txt
+COPY --from=builder /install /usr/local
+COPY . .
+
+ARG DETECTOR_MODEL=deepghs/real_face_detection
+ARG DETECTOR_FILE=face_detect_v1.4_s/model.onnx
+ARG EMBEDDER_MODEL_PATH=Xenova/clip-vit-base-patch32
+ARG EMBEDDER_FILE=model.onnx
+ENV DETECTOR_MODEL=$DETECTOR_MODEL \
+    DETECTOR_FILE=$DETECTOR_FILE \
+    EMBEDDER_MODEL_PATH=$EMBEDDER_MODEL_PATH \
+    EMBEDDER_FILE=$EMBEDDER_FILE
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "7860"]

--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -7,23 +7,28 @@ import io
 from typing import Optional
 import numpy as np
 from PIL import Image
-import onnxruntime as ort
-from huggingface_hub import hf_hub_download
+try:
+    import onnxruntime as ort
+except Exception:  # pragma: no cover - optional dependency
+    ort = None
+try:
+    from huggingface_hub import hf_hub_download
+except Exception:  # pragma: no cover - optional dependency
+    hf_hub_download = None
 import shutil
 
 # Requires: pip install dghs-imgutils
-from imgutils.detect.face import detect_faces
+try:
+    from imgutils.detect.face import detect_faces
+except Exception:  # pragma: no cover - optional dependency
+    detect_faces = None
 
 # Logging configuration
+logging.basicConfig(
+    level=getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
 logger = logging.getLogger(__name__)
-handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
-logger.addHandler(handler)
-
-level_name = os.getenv("FACE_API_LOG_LEVEL", "INFO").upper()
-level = getattr(logging, level_name, logging.INFO)
-logger.setLevel(level)
-handler.setLevel(level)
 
 # Constants and defaults
 DEFAULT_THRESHOLD_MAP = {
@@ -63,8 +68,8 @@ DEFAULT_THRESHOLD = float(os.getenv("DETECTOR_THRESHOLD",
 # Model loader class for modularity
 class ModelLoader:
     def __init__(self):
-        self._detector: Optional[ort.InferenceSession] = None
-        self._embedder: Optional[ort.InferenceSession] = None
+        self._detector: Optional[object] = None
+        self._embedder: Optional[object] = None
 
     def _get_providers(self):
         providers = []
@@ -88,7 +93,7 @@ class ModelLoader:
                 raise
         return local_path
 
-    def load_detector(self) -> ort.InferenceSession:
+    def load_detector(self):
         if self._detector is None:
             try:
                 cache_dir = os.path.expanduser("~/.cache/face_api/detector")
@@ -101,7 +106,7 @@ class ModelLoader:
                 raise
         return self._detector
 
-    def load_embedder(self) -> ort.InferenceSession:
+    def load_embedder(self):
         if self._embedder is None:
             try:
                 cache_dir = os.path.expanduser("~/.cache/face_api/embedder")
@@ -248,7 +253,7 @@ async def compare_faces(
 
 @app.get("/health")
 async def health_check():
-    return {"status": "healthy"}
+    return {"status": "ok", "model": DETECTOR_MODEL}
 
 @app.get("/models/info")
 async def models_info():
@@ -261,7 +266,7 @@ async def models_info():
 
 def main():  # pragma: no cover
     import uvicorn
-    log_level_name = os.getenv("FACE_API_LOG_LEVEL", "INFO").upper()
+    log_level_name = os.getenv("FACE_API_LOG_LEVEL", os.getenv("LOG_LEVEL", "INFO")).upper()
     uvicorn.run(app, host="0.0.0.0", port=7860, log_level=log_level_name.lower())
 
 if __name__ == "__main__":  # pragma: no cover

--- a/apps/onnx_chat/Dockerfile
+++ b/apps/onnx_chat/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim AS builder
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --prefix=/install --no-cache-dir -r requirements.txt
+COPY . .
+RUN pip install --prefix=/install --no-cache-dir .
+
+FROM python:3.10-slim
+WORKDIR /app
+COPY --from=builder /install /usr/local
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/onnx_chat/config.py
+++ b/apps/onnx_chat/config.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+import os
+import logging
+from dataclasses import dataclass
+
+@dataclass
+class Config:
+    model_path: str | None
+    port: int
+    log_level: str
+    host: str = "0.0.0.0"
+
+
+def load_config() -> Config:
+    """Read environment variables and validate any required ones."""
+    model_path = os.getenv("ONNX_MODEL_PATH")
+    if model_path and not os.path.exists(model_path):
+        raise FileNotFoundError(f"ONNX model path '{model_path}' does not exist")
+    port = int(os.getenv("COMFYAI_ONNX_PORT", "8000"))
+    log_level = os.getenv("ONNX_LOG_LEVEL", "info")
+    return Config(model_path=model_path, port=port, log_level=log_level)
+
+
+def setup_logging() -> None:
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )

--- a/apps/onnx_chat/main.py
+++ b/apps/onnx_chat/main.py
@@ -1,14 +1,22 @@
+from __future__ import annotations
 import os
 from typing import List, Dict, Any
+import argparse
+import logging
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError
 
+from .config import load_config, setup_logging
+
 try:
     import onnxruntime as ort
 except Exception:  # pragma: no cover - optional dependency
     ort = None
+
+setup_logging()
+config = load_config()
 
 app = FastAPI()
 
@@ -17,8 +25,14 @@ class ChatRequest(BaseModel):
     messages: List[Dict[str, Any]]
     max_tokens: int | None = None
 
+
+@app.get("/health")
+async def health_check():
+    model_name = os.path.basename(MODEL_PATH) if MODEL_PATH else "none"
+    return {"status": "ok", "model": model_name}
+
 session = None
-MODEL_PATH = os.environ.get("ONNX_MODEL_PATH")
+MODEL_PATH = config.model_path
 
 
 def load_session():
@@ -69,10 +83,23 @@ async def chat(request: Request):
     }
 
 
-def main():
+def main() -> None:
+    """CLI entry point for running the server via ``python -m``."""
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "8000")))
+    parser = argparse.ArgumentParser(description="ONNX chat completion server")
+    parser.add_argument("--host", default=config.host)
+    parser.add_argument("--port", type=int, default=config.port)
+    parser.add_argument("--reload", action="store_true")
+    args = parser.parse_args()
+
+    uvicorn.run(
+        "apps.onnx_chat.main:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        log_level=config.log_level,
+    )
 
 
 if __name__ == "__main__":

--- a/apps/onnx_chat/requirements.txt
+++ b/apps/onnx_chat/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+onnxruntime
+pydantic

--- a/integration_tests/test_server_api.py
+++ b/integration_tests/test_server_api.py
@@ -11,8 +11,8 @@ except Exception:  # pragma: no cover - optional
 if TestClient is None:
     pytest.skip("fastapi not available", allow_module_level=True)
 else:
-    from apps.onnx_server import app
-    import apps.onnx_server as onnx_server
+    from apps.onnx_chat.main import app
+    import apps.onnx_chat.main as onnx_server
 
 
 def _client(monkeypatch):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ numpy = "^1.23"
 requests = "^2.28"
 
 [project.scripts]
-comfyai-onnx-server = "apps.onnx_server:main"
+comfyai-onnx-server = "apps.onnx_chat.main:main"

--- a/tests/test_face_api.py
+++ b/tests/test_face_api.py
@@ -1,5 +1,12 @@
 import numpy as np
 import importlib, sys
+import os
+
+# Ensure mandatory env vars for import
+os.environ.setdefault("DETECTOR_MODEL", "fake")
+os.environ.setdefault("DETECTOR_FILE", "model.onnx")
+os.environ.setdefault("EMBEDDER_MODEL_PATH", "fake")
+os.environ.setdefault("EMBEDDER_FILE", "model.onnx")
 sys.modules.pop("fastapi", None)
 from fastapi.testclient import TestClient
 from apps.face_api.main import app
@@ -82,3 +89,16 @@ def test_provider_fallback(monkeypatch):
     assert calls["name"] == "foo"
     assert calls["providers"] == ["CPUExecutionProvider"]
     assert calls.get("prepared") is True
+
+
+def test_health_and_compare(monkeypatch):
+    monkeypatch.setattr(face_model, "get_embedding", lambda d: None)
+    monkeypatch.setattr(api_main, "get_embedding", lambda d: None)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    resp = client.post(
+        "/v1/image/compare_faces",
+        files={"image_a": ("a.png", b"A"), "image_b": ("b.png", b"B")},
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- move ONNX server into `apps/onnx_chat`
- expose a Dockerfile and requirements for the ONNX server
- add uvicorn-based entrypoint and script path updates
- document ONNX server and face API usage and container builds
- make face API imports optional for tests
- add health endpoints and unified logging

## Testing
- `pytest -q tests`
- `pytest -q integration_tests`


------
https://chatgpt.com/codex/tasks/task_e_6877915fe27083319951ad25b35e1355