### PR TITLE
Refactor face API configuration with presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,28 @@ pip install fastapi uvicorn insightface onnxruntime[-gpu] python-multipart
 uvicorn apps.face_api.main:app --host 0.0.0.0 --port 7860
 ```
 
-Set the environment variables above to tweak model selection or provider order.
+Configuration values are resolved in this order: **environment variables → CLI flags → presets**.
+Set the environment variables above or pass flags to override the built-in presets.
+
+Zero‑config example using a preset:
+
+```bash
+uvicorn apps.face_api.main:app --preset photo
+```
+
+Custom models via CLI flags:
+
+```bash
+uvicorn apps.face_api.main:app \
+  --detector-model deepghs/real_face_detection \
+  --detector-file face_detect_v1.4_s/model.onnx \
+  --embedder-model-path openailab/onnx-arcface-resnet100-ms1m \
+  --embedder-file model.onnx
+```
+
+Add or remove presets by editing `apps/face_api/presets.py`.
+
+Set environment variables to tweak model selection or provider order.
 
 ### Example Usage
 

--- a/apps/face_api/config.py
+++ b/apps/face_api/config.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+import os
+import sys
+import argparse
+import logging
+from dataclasses import dataclass
+
+from .presets import PRESETS
+
+
+class PresetLoader:
+    def __init__(self, presets: dict[str, dict]):
+        self.presets = presets
+
+    def get(self, name: str) -> dict:
+        if name not in self.presets:
+            valid = ", ".join(self.presets)
+            raise KeyError(f"Unknown preset '{name}'. Valid options: {valid}")
+        return self.presets[name]
+
+
+Preset = PresetLoader(PRESETS)
+
+
+@dataclass
+class Config:
+    detector_model: str
+    detector_file: str
+    embedder_model_path: str
+    embedder_file: str
+    threshold: float
+    preload_models: bool
+    preset_name: str | None = None
+    log_level: str = "info"
+
+
+def setup_logging() -> None:
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+
+_ENV_VARS = [
+    "DETECTOR_MODEL",
+    "DETECTOR_FILE",
+    "EMBEDDER_MODEL_PATH",
+    "EMBEDDER_FILE",
+    "DETECTOR_THRESHOLD",
+]
+
+
+def _cli_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--detector-model")
+    parser.add_argument("--detector-file")
+    parser.add_argument("--embedder-model-path")
+    parser.add_argument("--embedder-file")
+    parser.add_argument("--threshold", type=float)
+    parser.add_argument("--preset")
+    args, _ = parser.parse_known_args(argv)
+    return args
+
+
+def load_config(argv: list[str] | None = None) -> Config:
+    args = _cli_args(argv if argv is not None else sys.argv[1:])
+
+    preset_name = os.getenv("PRESET") or args.preset
+    preset = {}
+    if preset_name:
+        try:
+            preset = Preset.get(preset_name)
+        except KeyError as e:
+            raise SystemExit(str(e))
+
+    def pick(env_name: str, arg_val: str | None, key: str) -> str:
+        return os.getenv(env_name) or arg_val or preset.get(key, "")
+
+    detector_model = pick("DETECTOR_MODEL", args.detector_model, "detector_repo")
+    detector_file = pick("DETECTOR_FILE", args.detector_file, "detector_file")
+    embedder_model_path = pick("EMBEDDER_MODEL_PATH", args.embedder_model_path, "embedder_repo")
+    embedder_file = pick("EMBEDDER_FILE", args.embedder_file, "embedder_file")
+
+    thr_env = os.getenv("DETECTOR_THRESHOLD")
+    if thr_env is not None:
+        threshold = float(thr_env)
+    elif args.threshold is not None:
+        threshold = args.threshold
+    else:
+        threshold = float(preset.get("threshold", 0.5))
+
+    preload = os.getenv("PRELOAD_MODELS", "false").lower() in ("1", "true", "yes")
+
+    missing = [
+        name
+        for name, val in [
+            ("DETECTOR_MODEL", detector_model),
+            ("DETECTOR_FILE", detector_file),
+            ("EMBEDDER_MODEL_PATH", embedder_model_path),
+            ("EMBEDDER_FILE", embedder_file),
+        ]
+        if not val
+    ]
+    if missing:
+        raise SystemExit(f"Missing required settings: {', '.join(missing)}")
+
+    log_level = os.getenv("FACE_API_LOG_LEVEL", os.getenv("LOG_LEVEL", "INFO")).lower()
+
+    return Config(
+        detector_model=detector_model,
+        detector_file=detector_file,
+        embedder_model_path=embedder_model_path,
+        embedder_file=embedder_file,
+        threshold=threshold,
+        preload_models=preload,
+        preset_name=preset_name,
+        log_level=log_level,
+    )
+

--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -1,9 +1,9 @@
 from fastapi import FastAPI, UploadFile, File
 from fastapi.responses import JSONResponse
 import asyncio
+import io
 import logging
 import os
-import io
 from typing import Optional
 import numpy as np
 from PIL import Image
@@ -23,11 +23,10 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     detect_faces = None
 
-# Logging configuration
-logging.basicConfig(
-    level=getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO),
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
+from .config import load_config, setup_logging
+
+setup_logging()
+config = load_config()
 logger = logging.getLogger(__name__)
 
 # Constants and defaults
@@ -44,26 +43,15 @@ DEFAULT_THRESHOLD_MAP = {
     "face_detect_v1.1_s/model.onnx": 0.405,
 }
 
-DEFAULT_LEVEL = os.getenv("DETECTOR_LEVEL", "s")
-DEFAULT_VERSION = os.getenv("DETECTOR_VERSION", "v1.4")
+DEFAULT_LEVEL = "s"
+DEFAULT_VERSION = "v1.4"
 
-# Enforce mandatory environment variables
-def get_env_var(name: str) -> str:
-    value = os.getenv(name)
-    if not value:
-        logger.critical(f"Mandatory environment variable '{name}' is not set. Aborting.")
-        raise EnvironmentError(f"Mandatory environment variable '{name}' is not set.")
-    return value
+DETECTOR_MODEL = config.detector_model
+DETECTOR_FILE = config.detector_file
+EMBEDDER_MODEL_PATH = config.embedder_model_path
+EMBEDDER_FILE = config.embedder_file
 
-DETECTOR_MODEL = get_env_var("DETECTOR_MODEL")
-DETECTOR_FILE = get_env_var("DETECTOR_FILE")
-EMBEDDER_MODEL_PATH = get_env_var("EMBEDDER_MODEL_PATH")
-EMBEDDER_FILE = get_env_var("EMBEDDER_FILE")
-
-# Optional overrides
-DEFAULT_THRESHOLD = float(os.getenv("DETECTOR_THRESHOLD",
-    DEFAULT_THRESHOLD_MAP.get(DETECTOR_FILE, 0.5)
-))
+DEFAULT_THRESHOLD = config.threshold
 
 # Model loader class for modularity
 class ModelLoader:
@@ -155,7 +143,11 @@ def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
 app = FastAPI()
 model_loader = ModelLoader()
 
-PRELOAD_MODELS = os.getenv("PRELOAD_MODELS", "false").lower() in ("1", "true", "yes")
+app.state.detector_path = f"{DETECTOR_MODEL}/{DETECTOR_FILE}"
+app.state.embedder_path = f"{EMBEDDER_MODEL_PATH}/{EMBEDDER_FILE}"
+app.state.threshold = DEFAULT_THRESHOLD
+
+PRELOAD_MODELS = config.preload_models
 
 @app.on_event("startup")
 async def startup_event():
@@ -265,9 +257,46 @@ async def models_info():
     }
 
 def main():  # pragma: no cover
+    import argparse
     import uvicorn
-    log_level_name = os.getenv("FACE_API_LOG_LEVEL", os.getenv("LOG_LEVEL", "INFO")).upper()
-    uvicorn.run(app, host="0.0.0.0", port=7860, log_level=log_level_name.lower())
+
+    parser = argparse.ArgumentParser(description="Face comparison API")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=7860)
+    parser.add_argument("--detector-model")
+    parser.add_argument("--detector-file")
+    parser.add_argument("--embedder-model-path")
+    parser.add_argument("--embedder-file")
+    parser.add_argument("--threshold", type=float)
+    parser.add_argument("--preset")
+    args = parser.parse_args()
+
+    # reload config with CLI overrides
+    global config, DETECTOR_MODEL, DETECTOR_FILE, EMBEDDER_MODEL_PATH, EMBEDDER_FILE, DEFAULT_THRESHOLD, PRELOAD_MODELS
+    config = load_config([
+        f"--detector-model={args.detector_model}" if args.detector_model else "",
+        f"--detector-file={args.detector_file}" if args.detector_file else "",
+        f"--embedder-model-path={args.embedder_model_path}" if args.embedder_model_path else "",
+        f"--embedder-file={args.embedder_file}" if args.embedder_file else "",
+        f"--threshold={args.threshold}" if args.threshold is not None else "",
+        f"--preset={args.preset}" if args.preset else "",
+    ])
+    DETECTOR_MODEL = config.detector_model
+    DETECTOR_FILE = config.detector_file
+    EMBEDDER_MODEL_PATH = config.embedder_model_path
+    EMBEDDER_FILE = config.embedder_file
+    DEFAULT_THRESHOLD = config.threshold
+    PRELOAD_MODELS = config.preload_models
+    app.state.detector_path = f"{DETECTOR_MODEL}/{DETECTOR_FILE}"
+    app.state.embedder_path = f"{EMBEDDER_MODEL_PATH}/{EMBEDDER_FILE}"
+    app.state.threshold = DEFAULT_THRESHOLD
+
+    uvicorn.run(
+        "apps.face_api.main:app",
+        host=args.host,
+        port=args.port,
+        log_level=config.log_level,
+    )
 
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/apps/face_api/presets.py
+++ b/apps/face_api/presets.py
@@ -1,0 +1,23 @@
+PRESETS = {
+    "photo": {
+        "detector_repo": "deepghs/real_face_detection",
+        "detector_file": "face_detect_v1.4_s/model.onnx",
+        "embedder_repo": "openailab/onnx-arcface-resnet100-ms1m",
+        "embedder_file": "model.onnx",
+        "threshold": 0.446,
+    },
+    "anime": {
+        "detector_repo": "deepghs/anime_face_detection",
+        "detector_file": "face_detect_v1.4_s/model.onnx",
+        "embedder_repo": "Xenova/clip-vit-base-patch32",
+        "embedder_file": "onnx/vision_model.onnx",
+        "threshold": 0.307,
+    },
+    "cg": {
+        "detector_repo": "deepghs/real_face_detection",
+        "detector_file": "face_detect_v1.4_n/model.onnx",
+        "embedder_repo": "Xenova/clip-vit-base-patch32",
+        "embedder_file": "onnx/vision_model.onnx",
+        "threshold": 0.278,
+    },
+}

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+import os
+from apps.face_api.presets import PRESETS
+
+
+def _load_app(preset):
+    for var in [
+        "DETECTOR_MODEL",
+        "DETECTOR_FILE",
+        "EMBEDDER_MODEL_PATH",
+        "EMBEDDER_FILE",
+        "DETECTOR_THRESHOLD",
+    ]:
+        os.environ.pop(var, None)
+    os.environ["PRESET"] = preset
+    sys.modules.pop("fastapi", None)
+    sys.modules.pop("apps.face_api.main", None)
+    import apps.face_api.main as api_main
+    importlib.reload(api_main)
+    return api_main.app
+
+
+def test_presets(monkeypatch):
+    for name, preset in PRESETS.items():
+        app = _load_app(name)
+        assert app.state.detector_path == f"{preset['detector_repo']}/{preset['detector_file']}"
+        assert app.state.embedder_path == f"{preset['embedder_repo']}/{preset['embedder_file']}"
+        assert abs(app.state.threshold - preset['threshold']) < 1e-6
+
+


### PR DESCRIPTION
## Summary
- centralize face API config handling
- add presets module and loader
- expose detector and embedder paths on `app.state`
- document override order and CLI examples
- test preset configuration logic

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q fastapi uvicorn onnxruntime numpy pillow`
- `pip install -q httpx python-multipart`
- `pytest -q tests`
- `pytest -q integration_tests`

------
https://chatgpt.com/codex/tasks/task_e_687839259e7083318306dca174d1f41a