### PR TITLE
Refactor face API configuration using presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ pip install comfyai[onnx]
 - `EMBEDDER_MODEL_PATH` – repository for the embedding model
 - `EMBEDDER_FILE` – path to the embedder ONNX file
 - `DETECTOR_THRESHOLD` – optional threshold override (default per model)
+- `PRESET` – named configuration defined in `apps/face_api/presets.py`
+
+Configuration precedence is **environment variables → CLI flags → presets**.
+Add or remove presets by editing `apps/face_api/presets.py` only.
 
 ### Face Comparison API Installation
 
@@ -208,6 +212,29 @@ uvicorn apps.face_api.main:app --host 0.0.0.0 --port 7860
 ```
 
 Set the environment variables above to tweak model selection or provider order.
+
+Zero configuration (uses the `photo` preset):
+
+```bash
+python -m apps.face_api.main
+```
+
+Select another preset:
+
+```bash
+PRESET=anime python -m apps.face_api.main
+```
+
+Override models via CLI:
+
+```bash
+python -m apps.face_api.main \
+  --detector_model deepghs/anime_face_detection \
+  --detector_file face_detect_v1.4_s/model.onnx \
+  --embedder_repo Xenova/clip-vit-base-patch32 \
+  --embedder_file onnx/vision_model.onnx \
+  --threshold 0.3
+```
 
 ### Example Usage
 

--- a/apps/face_api/config.py
+++ b/apps/face_api/config.py
@@ -1,0 +1,49 @@
+import os
+import argparse
+from .presets import PRESETS, PresetLoader
+
+Preset = PresetLoader(PRESETS)
+
+
+def _parse_cli():
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--preset")
+    parser.add_argument("--detector_model")
+    parser.add_argument("--detector_file")
+    parser.add_argument("--embedder_repo")
+    parser.add_argument("--embedder_file")
+    parser.add_argument("--threshold", type=float)
+    args, _ = parser.parse_known_args()
+    return args
+
+
+def load_config():
+    args = _parse_cli()
+    env = os.environ
+
+    preset_name = env.get("PRESET") or args.preset or "photo"
+    try:
+        preset = Preset.get(preset_name)
+    except KeyError as e:
+        raise ValueError(str(e)) from e
+
+    detector_model = env.get("DETECTOR_MODEL") or args.detector_model or preset["detector_repo"]
+    detector_file = env.get("DETECTOR_FILE") or args.detector_file or preset["detector_file"]
+    embedder_repo = env.get("EMBEDDER_MODEL_PATH") or args.embedder_repo or preset["embedder_repo"]
+    embedder_file = env.get("EMBEDDER_FILE") or args.embedder_file or preset["embedder_file"]
+
+    if env.get("DETECTOR_THRESHOLD") is not None:
+        threshold = float(env["DETECTOR_THRESHOLD"])
+    elif args.threshold is not None:
+        threshold = float(args.threshold)
+    else:
+        threshold = float(preset["threshold"])
+
+    return {
+        "DETECTOR_MODEL": detector_model,
+        "DETECTOR_FILE": detector_file,
+        "EMBEDDER_MODEL_PATH": embedder_repo,
+        "EMBEDDER_FILE": embedder_file,
+        "DEFAULT_THRESHOLD": threshold,
+        "PRESET_NAME": preset_name,
+    }

--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -16,6 +16,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     hf_hub_download = None
 import shutil
+from .config import load_config, Preset
 
 # Requires: pip install dghs-imgutils
 try:
@@ -30,40 +31,13 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Constants and defaults
-DEFAULT_THRESHOLD_MAP = {
-    "face_detect_v1.4_s/model.onnx": 0.307,
-    "face_detect_v1.4_n/model.onnx": 0.278,
-    "face_detect_v1.3_n/model.onnx": 0.305,
-    "face_detect_v1.2_s/model.onnx": 0.222,
-    "face_detect_v1.3_s/model.onnx": 0.259,
-    "face_detect_v1_s/model.onnx": 0.446,
-    "face_detect_v1_n/model.onnx": 0.458,
-    "face_detect_v0_n/model.onnx": 0.428,
-    "face_detect_v1.1_n/model.onnx": 0.373,
-    "face_detect_v1.1_s/model.onnx": 0.405,
-}
-
-DEFAULT_LEVEL = os.getenv("DETECTOR_LEVEL", "s")
-DEFAULT_VERSION = os.getenv("DETECTOR_VERSION", "v1.4")
-
-# Enforce mandatory environment variables
-def get_env_var(name: str) -> str:
-    value = os.getenv(name)
-    if not value:
-        logger.critical(f"Mandatory environment variable '{name}' is not set. Aborting.")
-        raise EnvironmentError(f"Mandatory environment variable '{name}' is not set.")
-    return value
-
-DETECTOR_MODEL = get_env_var("DETECTOR_MODEL")
-DETECTOR_FILE = get_env_var("DETECTOR_FILE")
-EMBEDDER_MODEL_PATH = get_env_var("EMBEDDER_MODEL_PATH")
-EMBEDDER_FILE = get_env_var("EMBEDDER_FILE")
-
-# Optional overrides
-DEFAULT_THRESHOLD = float(os.getenv("DETECTOR_THRESHOLD",
-    DEFAULT_THRESHOLD_MAP.get(DETECTOR_FILE, 0.5)
-))
+# Configuration
+cfg = load_config()
+DETECTOR_MODEL = cfg["DETECTOR_MODEL"]
+DETECTOR_FILE = cfg["DETECTOR_FILE"]
+EMBEDDER_MODEL_PATH = cfg["EMBEDDER_MODEL_PATH"]
+EMBEDDER_FILE = cfg["EMBEDDER_FILE"]
+DEFAULT_THRESHOLD = cfg["DEFAULT_THRESHOLD"]
 
 # Model loader class for modularity
 class ModelLoader:
@@ -153,6 +127,9 @@ def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
 
 # FastAPI app and model loader instance
 app = FastAPI()
+app.state.detector_path = f"{DETECTOR_MODEL}/{DETECTOR_FILE}"
+app.state.embedder_path = f"{EMBEDDER_MODEL_PATH}/{EMBEDDER_FILE}"
+app.state.threshold = DEFAULT_THRESHOLD
 model_loader = ModelLoader()
 
 PRELOAD_MODELS = os.getenv("PRELOAD_MODELS", "false").lower() in ("1", "true", "yes")
@@ -178,8 +155,6 @@ def get_embedding(image_bytes: bytes) -> Optional[np.ndarray]:
 
         raw_faces = detect_faces(
             img,
-            level=DEFAULT_LEVEL,
-            version=DEFAULT_VERSION,
             conf_threshold=DEFAULT_THRESHOLD
         )
         faces = [bbox for (bbox, _, _) in raw_faces]

--- a/apps/face_api/presets.py
+++ b/apps/face_api/presets.py
@@ -1,0 +1,37 @@
+class PresetLoader:
+    def __init__(self, presets: dict):
+        self._presets = presets
+
+    def get(self, name: str) -> dict:
+        if name not in self._presets:
+            valid = ", ".join(sorted(self._presets))
+            raise KeyError(f"Unknown preset '{name}'. Valid presets: {valid}")
+        return self._presets[name]
+
+    def keys(self):
+        return self._presets.keys()
+
+
+PRESETS = {
+    "photo": {
+        "detector_repo": "deepghs/real_face_detection",
+        "detector_file": "face_detect_v1.4_s/model.onnx",
+        "embedder_repo": "openailab/onnx-arcface-resnet100-ms1m",
+        "embedder_file": "model.onnx",
+        "threshold": 0.446,
+    },
+    "anime": {
+        "detector_repo": "deepghs/anime_face_detection",
+        "detector_file": "face_detect_v1.4_s/model.onnx",
+        "embedder_repo": "Xenova/clip-vit-base-patch32",
+        "embedder_file": "onnx/vision_model.onnx",
+        "threshold": 0.307,
+    },
+    "cg": {
+        "detector_repo": "deepghs/real_face_detection",
+        "detector_file": "face_detect_v1.4_n/model.onnx",
+        "embedder_repo": "Xenova/clip-vit-base-patch32",
+        "embedder_file": "onnx/vision_model.onnx",
+        "threshold": 0.278,
+    },
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,9 @@ if repo_root not in sys.path:
 
 # Stub heavy modules so imports never fail
 import importlib.machinery
+import importlib.util
 for mod in ("torch", "onnxruntime", "fastapi", "uvicorn"):
-    if mod not in sys.modules:
+    if mod not in sys.modules and importlib.util.find_spec(mod) is None:
         module = types.ModuleType(mod)
         module.__spec__ = importlib.machinery.ModuleSpec(mod, loader=None)
         sys.modules[mod] = module

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,44 @@
+import importlib
+import os
+import sys
+
+from apps.face_api.presets import PRESETS
+from fastapi.testclient import TestClient
+
+
+def load_app(preset: str):
+    os.environ["PRESET"] = preset
+    for var in (
+        "DETECTOR_MODEL",
+        "DETECTOR_FILE",
+        "EMBEDDER_MODEL_PATH",
+        "EMBEDDER_FILE",
+        "DETECTOR_THRESHOLD",
+    ):
+        os.environ.pop(var, None)
+    sys.modules.pop("apps.face_api.main", None)
+    import apps.face_api.main as main
+    importlib.reload(main)
+    return main.app
+
+
+def check_preset(preset_name: str):
+    app = load_app(preset_name)
+    TestClient(app)  # trigger startup
+    preset = PRESETS[preset_name]
+    assert app.state.detector_path == f"{preset['detector_repo']}/{preset['detector_file']}"
+    assert app.state.embedder_path == f"{preset['embedder_repo']}/{preset['embedder_file']}"
+    assert app.state.threshold == preset['threshold']
+
+
+def test_photo_preset():
+    check_preset("photo")
+
+
+def test_anime_preset():
+    check_preset("anime")
+
+
+def test_cg_preset():
+    check_preset("cg")
+


### PR DESCRIPTION
## Summary
- externalize presets to `apps/face_api/presets.py`
- centralise loading logic in `apps/face_api/config.py`
- refactor face API to use new config and store preset info on `app.state`
- update README with configuration precedence and CLI examples
- add tests for preset handling
- tweak test stubs to skip installed packages

## Testing
- `pytest tests -vv`
- `pytest integration_tests -q`

------
https://chatgpt.com/codex/tasks/task_e_687839259e7083318306dca174d1f41a