### PR TITLE
Refactor face API presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ pip install comfyai[onnx]
 - `EMBEDDER_MODEL_PATH` – repository for the embedding model
 - `EMBEDDER_FILE` – path to the embedder ONNX file
 - `DETECTOR_THRESHOLD` – optional threshold override (default per model)
+- `PRESET` – name of a face-api preset (`photo`, `anime`, `cg`)
+
+Environment variables override CLI flags which override the selected preset.
+Add or remove presets by editing `apps/face_api/presets.py`.
 
 ### Face Comparison API Installation
 
@@ -205,6 +209,18 @@ pip install fastapi uvicorn insightface onnxruntime[-gpu] python-multipart
 
 ```bash
 uvicorn apps.face_api.main:app --host 0.0.0.0 --port 7860
+```
+
+Zero-config:
+
+```bash
+python -m apps.face_api.main
+```
+
+Custom models via CLI flags:
+
+```bash
+python -m apps.face_api.main --preset anime --threshold 0.3
 ```
 
 Set the environment variables above to tweak model selection or provider order.

--- a/apps/face_api/config.py
+++ b/apps/face_api/config.py
@@ -1,0 +1,57 @@
+import argparse
+import os
+from .presets import PRESETS, PresetLoader
+
+Preset = PresetLoader(PRESETS)
+
+
+def load_config(argv=None):
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--preset")
+    parser.add_argument("--detector-model")
+    parser.add_argument("--detector-file")
+    parser.add_argument("--embedder-model-path")
+    parser.add_argument("--embedder-file")
+    parser.add_argument("--threshold", type=float)
+    args, _ = parser.parse_known_args(argv)
+
+    env = os.environ
+
+    preset_name = env.get("PRESET")
+    if preset_name is None:
+        preset_name = args.preset or "photo"
+
+    cli_overrides = {
+        "detector_repo": args.detector_model,
+        "detector_file": args.detector_file,
+        "embedder_repo": args.embedder_model_path,
+        "embedder_file": args.embedder_file,
+        "threshold": args.threshold,
+    }
+
+    preset = Preset.get(preset_name)
+
+    def choose(key, env_name):
+        if env.get(env_name) is not None:
+            return env[env_name]
+        if cli_overrides.get(key) is not None:
+            return cli_overrides[key]
+        return preset[key]
+
+    cfg = {
+        "PRESET_NAME": preset_name,
+        "DETECTOR_MODEL": choose("detector_repo", "DETECTOR_MODEL"),
+        "DETECTOR_FILE": choose("detector_file", "DETECTOR_FILE"),
+        "EMBEDDER_MODEL_PATH": choose("embedder_repo", "EMBEDDER_MODEL_PATH"),
+        "EMBEDDER_FILE": choose("embedder_file", "EMBEDDER_FILE"),
+    }
+
+    thr_env = env.get("DETECTOR_THRESHOLD")
+    if thr_env is not None:
+        cfg["DEFAULT_THRESHOLD"] = float(thr_env)
+    elif cli_overrides.get("threshold") is not None:
+        cfg["DEFAULT_THRESHOLD"] = cli_overrides["threshold"]
+    else:
+        cfg["DEFAULT_THRESHOLD"] = preset["threshold"]
+
+    return cfg

--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -30,40 +30,16 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Constants and defaults
-DEFAULT_THRESHOLD_MAP = {
-    "face_detect_v1.4_s/model.onnx": 0.307,
-    "face_detect_v1.4_n/model.onnx": 0.278,
-    "face_detect_v1.3_n/model.onnx": 0.305,
-    "face_detect_v1.2_s/model.onnx": 0.222,
-    "face_detect_v1.3_s/model.onnx": 0.259,
-    "face_detect_v1_s/model.onnx": 0.446,
-    "face_detect_v1_n/model.onnx": 0.458,
-    "face_detect_v0_n/model.onnx": 0.428,
-    "face_detect_v1.1_n/model.onnx": 0.373,
-    "face_detect_v1.1_s/model.onnx": 0.405,
-}
+from .config import load_config
 
-DEFAULT_LEVEL = os.getenv("DETECTOR_LEVEL", "s")
-DEFAULT_VERSION = os.getenv("DETECTOR_VERSION", "v1.4")
-
-# Enforce mandatory environment variables
-def get_env_var(name: str) -> str:
-    value = os.getenv(name)
-    if not value:
-        logger.critical(f"Mandatory environment variable '{name}' is not set. Aborting.")
-        raise EnvironmentError(f"Mandatory environment variable '{name}' is not set.")
-    return value
-
-DETECTOR_MODEL = get_env_var("DETECTOR_MODEL")
-DETECTOR_FILE = get_env_var("DETECTOR_FILE")
-EMBEDDER_MODEL_PATH = get_env_var("EMBEDDER_MODEL_PATH")
-EMBEDDER_FILE = get_env_var("EMBEDDER_FILE")
-
-# Optional overrides
-DEFAULT_THRESHOLD = float(os.getenv("DETECTOR_THRESHOLD",
-    DEFAULT_THRESHOLD_MAP.get(DETECTOR_FILE, 0.5)
-))
+config = load_config()
+DETECTOR_MODEL = config["DETECTOR_MODEL"]
+DETECTOR_FILE = config["DETECTOR_FILE"]
+EMBEDDER_MODEL_PATH = config["EMBEDDER_MODEL_PATH"]
+EMBEDDER_FILE = config["EMBEDDER_FILE"]
+DEFAULT_THRESHOLD = config["DEFAULT_THRESHOLD"]
+DEFAULT_LEVEL = "s"
+DEFAULT_VERSION = "v1.4"
 
 # Model loader class for modularity
 class ModelLoader:
@@ -154,6 +130,9 @@ def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
 # FastAPI app and model loader instance
 app = FastAPI()
 model_loader = ModelLoader()
+app.state.detector_path = f"{DETECTOR_MODEL}/{DETECTOR_FILE}"
+app.state.embedder_path = f"{EMBEDDER_MODEL_PATH}/{EMBEDDER_FILE}"
+app.state.threshold = DEFAULT_THRESHOLD
 
 PRELOAD_MODELS = os.getenv("PRELOAD_MODELS", "false").lower() in ("1", "true", "yes")
 
@@ -265,7 +244,18 @@ async def models_info():
     }
 
 def main():  # pragma: no cover
+    import sys
     import uvicorn
+    global config, DETECTOR_MODEL, DETECTOR_FILE, EMBEDDER_MODEL_PATH, EMBEDDER_FILE, DEFAULT_THRESHOLD
+    config = load_config(sys.argv[1:])
+    DETECTOR_MODEL = config["DETECTOR_MODEL"]
+    DETECTOR_FILE = config["DETECTOR_FILE"]
+    EMBEDDER_MODEL_PATH = config["EMBEDDER_MODEL_PATH"]
+    EMBEDDER_FILE = config["EMBEDDER_FILE"]
+    DEFAULT_THRESHOLD = config["DEFAULT_THRESHOLD"]
+    app.state.detector_path = f"{DETECTOR_MODEL}/{DETECTOR_FILE}"
+    app.state.embedder_path = f"{EMBEDDER_MODEL_PATH}/{EMBEDDER_FILE}"
+    app.state.threshold = DEFAULT_THRESHOLD
     log_level_name = os.getenv("FACE_API_LOG_LEVEL", os.getenv("LOG_LEVEL", "INFO")).upper()
     uvicorn.run(app, host="0.0.0.0", port=7860, log_level=log_level_name.lower())
 

--- a/apps/face_api/presets.py
+++ b/apps/face_api/presets.py
@@ -1,0 +1,36 @@
+PRESETS = {
+    "photo": {
+        "detector_repo":    "deepghs/real_face_detection",
+        "detector_file":    "face_detect_v1.4_s/model.onnx",
+        "embedder_repo":    "openailab/onnx-arcface-resnet100-ms1m",
+        "embedder_file":    "model.onnx",
+        "threshold":        0.446,
+    },
+    "anime": {
+        "detector_repo":    "deepghs/anime_face_detection",
+        "detector_file":    "face_detect_v1.4_s/model.onnx",
+        "embedder_repo":    "Xenova/clip-vit-base-patch32",
+        "embedder_file":    "onnx/vision_model.onnx",
+        "threshold":        0.307,
+    },
+    "cg": {
+        "detector_repo":    "deepghs/real_face_detection",
+        "detector_file":    "face_detect_v1.4_n/model.onnx",
+        "embedder_repo":    "Xenova/clip-vit-base-patch32",
+        "embedder_file":    "onnx/vision_model.onnx",
+        "threshold":        0.278,
+    },
+}
+
+class PresetLoader:
+    def __init__(self, presets: dict):
+        self._presets = presets
+
+    def get(self, name: str) -> dict:
+        if name not in self._presets:
+            valid = ", ".join(sorted(self._presets))
+            raise ValueError(f"Unknown preset '{name}'. Valid presets: {valid}")
+        return self._presets[name]
+
+    def keys(self):
+        return self._presets.keys()

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,30 @@
+import importlib
+import os
+import sys
+
+from apps.face_api.presets import PRESETS
+
+
+def load_app(preset_name):
+    for key in [
+        "DETECTOR_MODEL",
+        "DETECTOR_FILE",
+        "EMBEDDER_MODEL_PATH",
+        "EMBEDDER_FILE",
+        "DETECTOR_THRESHOLD",
+    ]:
+        os.environ.pop(key, None)
+    os.environ["PRESET"] = preset_name
+    sys.modules.pop("fastapi", None)
+    mod = importlib.reload(importlib.import_module("apps.face_api.main"))
+    return mod.app
+
+
+for name in PRESETS.keys():
+    def _test(name=name):
+        app = load_app(name)
+        preset = PRESETS[name]
+        assert app.state.detector_path == f"{preset['detector_repo']}/{preset['detector_file']}"
+        assert app.state.embedder_path == f"{preset['embedder_repo']}/{preset['embedder_file']}"
+        assert abs(app.state.threshold - preset['threshold']) < 1e-6
+    globals()[f"test_preset_{name}"] = _test


### PR DESCRIPTION
## Summary
- move face-api presets to dedicated module
- add config loader using presets, envvars and CLI flags
- expose preset info on app.state
- test each preset
- document preset overrides in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687839259e7083318306dca174d1f41a