### PR TITLE
Remove API client example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,24 +206,6 @@ uvicorn apps.face_api.main:app \
 
 Edit `apps/face_api/presets.py` to add or remove presets.
 
-### Example Usage
-
-```python
-from comfyai import openai_client
-
-# Remote:
-client = openai_client(api_key="…")
-
-# Local ONNX:
-client = openai_client(endpoint="http://localhost:8000/v1/chat/completions")
-
-response = client.create(
-model="qwen2.5",
-messages=[{"role":"user","content":"Hello"}]
-)
-print(response)
-```
-
 ### Testing
 
 ```bash


### PR DESCRIPTION
## Summary
- clean up README example code

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878510a2e1883319ce1b7a2161b8806