### PR TITLE
Enable dynamic model loading for ONNX chat server

### DIFF
--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -11,10 +11,7 @@ try:
     import onnxruntime as ort
 except Exception:  # pragma: no cover - optional dependency
     ort = None
-try:
-    from huggingface_hub import hf_hub_download
-except Exception:  # pragma: no cover - optional dependency
-    hf_hub_download = None
+from apps.hf_utils import download_model
 import shutil
 
 # Requires: pip install dghs-imgutils
@@ -70,18 +67,14 @@ class ModelLoader:
         return providers
 
     def _download_model(self, model_id: str, filename: str, cache_dir: str) -> str:
-        local_path = os.path.join(cache_dir, filename)
-        os.makedirs(os.path.dirname(local_path), exist_ok=True)
-
-        if not os.path.exists(local_path):
-            try:
-                downloaded_path = hf_hub_download(repo_id=model_id, filename=filename)
-                shutil.copy(downloaded_path, local_path)
-                logger.info(f"Downloaded {model_id}/{filename} to {local_path}")
-            except Exception as e:
-                logger.exception(f"Failed to download model {model_id}/{filename}; aborting startup")
-                raise
-        return local_path
+        """Wrapper around :func:`apps.hf_utils.download_model`."""
+        try:
+            return download_model(model_id, filename, cache_dir)
+        except Exception as e:
+            logger.exception(
+                f"Failed to download model {model_id}/{filename}; aborting startup"
+            )
+            raise
 
     def load_detector(self):
         if self._detector is None:

--- a/apps/hf_utils.py
+++ b/apps/hf_utils.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import os
+import shutil
+
+try:
+    from huggingface_hub import hf_hub_download
+except Exception:  # pragma: no cover - optional dependency
+    hf_hub_download = None  # type: ignore
+
+
+def download_model(repo_id: str, filename: str, cache_dir: str) -> str:
+    """Download a file from Hugging Face with caching.
+
+    Parameters
+    ----------
+    repo_id: str
+        Repository ID on Hugging Face.
+    filename: str
+        File path within the repository.
+    cache_dir: str
+        Local directory to copy the file into.
+
+    Returns
+    -------
+    str
+        Path to the downloaded file within ``cache_dir``.
+    """
+    local_path = os.path.join(cache_dir, filename)
+    os.makedirs(os.path.dirname(local_path), exist_ok=True)
+
+    if not os.path.exists(local_path):
+        if hf_hub_download is None:
+            raise RuntimeError("huggingface_hub is required to download models")
+        downloaded_path = hf_hub_download(repo_id=repo_id, filename=filename)
+        shutil.copy(downloaded_path, local_path)
+    return local_path

--- a/apps/onnx_chat/README.md
+++ b/apps/onnx_chat/README.md
@@ -1,6 +1,7 @@
 # ONNX Chat Completion Server
 
-A minimal OpenAI-compatible endpoint that can run an ONNX model for text classification or fall back to simple rules.
+A minimal OpenAI-compatible endpoint that can run an ONNX model for text classification or fall back to simple rules. Models
+can be referenced directly from Hugging Face by passing ``repo_id/path/to/file.onnx`` in the ``model`` field.
 
 ## Installation
 
@@ -18,7 +19,7 @@ python -m apps.onnx_chat.main
 
 ### Configuration
 
-- `ONNX_MODEL_PATH` – path to an ONNX model to load (optional)
+- `ONNX_MODEL_PATH` – optional path to preload a local ONNX model
 - `COMFYAI_ONNX_PORT` – listening port (default `8000`)
 - `ONNX_LOG_LEVEL` – uvicorn log level (default `info`)
 - `LOG_LEVEL` – Python logging level

--- a/apps/onnx_chat/main.py
+++ b/apps/onnx_chat/main.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 import os
 from typing import List, Dict, Any
 import argparse
-import logging
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError
 
 from .config import load_config, setup_logging
+from apps.hf_utils import download_model
 
 try:
     import onnxruntime as ort
@@ -28,21 +28,33 @@ class ChatRequest(BaseModel):
 
 @app.get("/health")
 async def health_check():
-    model_name = os.path.basename(MODEL_PATH) if MODEL_PATH else "none"
+    model_name = os.path.basename(config.model_path) if config.model_path else "none"
     return {"status": "ok", "model": model_name}
 
-session = None
-MODEL_PATH = config.model_path
+CACHE_ROOT = os.path.expanduser("~/.cache/onnx_chat")
+_SESSIONS: dict[str, Any] = {}
 
 
-def load_session():
-    global session
-    if session is None and ort and MODEL_PATH and os.path.exists(MODEL_PATH):
-        session = ort.InferenceSession(MODEL_PATH)
+def _get_session(model_id: str):
+    if model_id in _SESSIONS:
+        return _SESSIONS[model_id]
+    if ort is None:
+        return None
+    path = model_id
+    if not os.path.exists(path):
+        try:
+            repo_id, filename = model_id.rsplit("/", 1)
+        except ValueError:
+            return None
+        cache_dir = os.path.join(CACHE_ROOT, repo_id)
+        path = download_model(repo_id, filename, cache_dir)
+    session = ort.InferenceSession(path)
+    _SESSIONS[model_id] = session
+    return session
 
 
-def classify(text: str) -> str:
-    load_session()
+def classify(text: str, model_id: str) -> str:
+    session = _get_session(model_id)
     if session is None:
         # Fallback simple rule when ONNX model is unavailable
         return "positive" if "good" in text.lower() else "negative"
@@ -72,7 +84,7 @@ async def chat(request: Request):
                     text += part.get("text", "")
         else:
             text = str(content)
-    result = classify(text)
+    result = classify(text, req.model)
     return {
         "id": "cmpl-001",
         "object": "chat.completion",

--- a/integration_tests/test_server_api.py
+++ b/integration_tests/test_server_api.py
@@ -19,7 +19,7 @@ def _client(monkeypatch):
     if TestClient is None:
         pytest.skip("fastapi not available")
     # ensure classify returns predictable output
-    monkeypatch.setattr(onnx_server, "classify", lambda text: "positive")
+    monkeypatch.setattr(onnx_server, "classify", lambda text, model: "positive")
     return TestClient(app)
 
 

--- a/tests/test_onnx_chat.py
+++ b/tests/test_onnx_chat.py
@@ -1,0 +1,57 @@
+import os
+from types import SimpleNamespace
+import sys
+sys.modules.pop("fastapi", None)
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("ONNX_MODEL_PATH", "")
+
+import apps.onnx_chat.main as chat_main
+from apps import hf_utils
+
+client = TestClient(chat_main.app)
+
+
+def test_dynamic_load(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_download(repo_id, filename, cache_dir):
+        called['repo_id'] = repo_id
+        called['filename'] = filename
+        called['cache_dir'] = cache_dir
+        path = tmp_path / filename
+        path.touch()
+        return str(path)
+
+    class FakeSession:
+        def __init__(self, path):
+            called['path'] = path
+        def get_inputs(self):
+            class Inp: pass
+            inp = Inp(); inp.name = 'in'
+            return [inp]
+        def run(self, *_):
+            return [[123]]
+
+    monkeypatch.setattr(hf_utils, 'download_model', fake_download)
+    monkeypatch.setattr(chat_main, 'download_model', fake_download)
+    monkeypatch.setattr(chat_main, 'ort', SimpleNamespace(InferenceSession=FakeSession))
+    chat_main._SESSIONS.clear()
+
+    resp = client.post('/v1/chat/completions', json={
+        'model': 'repo/model.onnx',
+        'messages': [{'role': 'user', 'content': 'hi'}]
+    })
+    assert resp.status_code == 200
+    assert resp.json()['choices'][0]['message']['content'] == '123'
+    assert called['repo_id'] == 'repo'
+    assert called['filename'] == 'model.onnx'
+
+    # second request should reuse cached session
+    called.clear()
+    resp = client.post('/v1/chat/completions', json={
+        'model': 'repo/model.onnx',
+        'messages': [{'role': 'user', 'content': 'bye'}]
+    })
+    assert resp.status_code == 200
+    assert called == {}


### PR DESCRIPTION
## Summary
- factor out a shared HuggingFace download helper
- reuse download helper in face API
- load ONNX models dynamically in the chat server
- document new behaviour in the chat server README
- adjust integration test stubs and add new unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68787ab27a088331a06c568b4b937ea5