### PR TITLE
Enable HF model loading for chat server

### DIFF
--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -11,11 +11,7 @@ try:
     import onnxruntime as ort
 except Exception:  # pragma: no cover - optional dependency
     ort = None
-try:
-    from huggingface_hub import hf_hub_download
-except Exception:  # pragma: no cover - optional dependency
-    hf_hub_download = None
-import shutil
+from apps.shared.hf_utils import download_model
 
 # Requires: pip install dghs-imgutils
 try:
@@ -69,25 +65,12 @@ class ModelLoader:
         providers.append("CPUExecutionProvider")
         return providers
 
-    def _download_model(self, model_id: str, filename: str, cache_dir: str) -> str:
-        local_path = os.path.join(cache_dir, filename)
-        os.makedirs(os.path.dirname(local_path), exist_ok=True)
-
-        if not os.path.exists(local_path):
-            try:
-                downloaded_path = hf_hub_download(repo_id=model_id, filename=filename)
-                shutil.copy(downloaded_path, local_path)
-                logger.info(f"Downloaded {model_id}/{filename} to {local_path}")
-            except Exception as e:
-                logger.exception(f"Failed to download model {model_id}/{filename}; aborting startup")
-                raise
-        return local_path
 
     def load_detector(self):
         if self._detector is None:
             try:
                 cache_dir = os.path.expanduser("~/.cache/face_api/detector")
-                model_path = self._download_model(DETECTOR_MODEL, DETECTOR_FILE, cache_dir)
+                model_path = download_model(DETECTOR_MODEL, DETECTOR_FILE, cache_dir)
                 providers = self._get_providers()
                 self._detector = ort.InferenceSession(model_path, providers=providers)
                 logger.info(f"Loaded detector model from {model_path}")
@@ -100,7 +83,7 @@ class ModelLoader:
         if self._embedder is None:
             try:
                 cache_dir = os.path.expanduser("~/.cache/face_api/embedder")
-                model_path = self._download_model(EMBEDDER_MODEL_PATH, EMBEDDER_FILE, cache_dir)
+                model_path = download_model(EMBEDDER_MODEL_PATH, EMBEDDER_FILE, cache_dir)
                 providers = self._get_providers()
                 self._embedder = ort.InferenceSession(model_path, providers=providers)
                 logger.info(f"Loaded embedder model from {model_path}")

--- a/apps/onnx_chat/README.md
+++ b/apps/onnx_chat/README.md
@@ -16,9 +16,14 @@ pip install -r apps/onnx_chat/requirements.txt
 python -m apps.onnx_chat.main
 ```
 
+The server can download ONNX models from Hugging Face on demand. Pass the
+`model` field as `"repo_id[:filename]"` in your request. If `filename` is omitted,
+`model.onnx` is assumed. Files are cached under `~/.cache/onnx_chat/`.
+
 ### Configuration
 
 - `ONNX_MODEL_PATH` – path to an ONNX model to load (optional)
+- `ONNX_FILE_NAME` – default filename when downloading from Hugging Face
 - `COMFYAI_ONNX_PORT` – listening port (default `8000`)
 - `ONNX_LOG_LEVEL` – uvicorn log level (default `info`)
 - `LOG_LEVEL` – Python logging level

--- a/apps/onnx_chat/main.py
+++ b/apps/onnx_chat/main.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError
 
 from .config import load_config, setup_logging
+from apps.shared.hf_utils import download_model
 
 try:
     import onnxruntime as ort
@@ -17,6 +18,10 @@ except Exception:  # pragma: no cover - optional dependency
 
 setup_logging()
 config = load_config()
+
+sessions: dict[str, object | None] = {}
+MODEL_PATH = config.model_path
+DEFAULT_FILE = os.getenv("ONNX_FILE_NAME", "model.onnx")
 
 app = FastAPI()
 
@@ -31,18 +36,38 @@ async def health_check():
     model_name = os.path.basename(MODEL_PATH) if MODEL_PATH else "none"
     return {"status": "ok", "model": model_name}
 
-session = None
-MODEL_PATH = config.model_path
+
+def _ensure_model_path(name: str) -> str | None:
+    if os.path.exists(name):
+        return name
+    repo_id, filename = (name.split(":", 1) + [DEFAULT_FILE])[:2]
+    cache_dir = os.path.expanduser("~/.cache/onnx_chat")
+    try:
+        return download_model(repo_id, filename, cache_dir)
+    except Exception:
+        logging.getLogger(__name__).exception("Failed to download %s", name)
+        return None
 
 
-def load_session():
-    global session
-    if session is None and ort and MODEL_PATH and os.path.exists(MODEL_PATH):
-        session = ort.InferenceSession(MODEL_PATH)
+def load_session(model_name: str) -> object | None:
+    if model_name not in sessions:
+        if ort is None:
+            sessions[model_name] = None
+        else:
+            path = _ensure_model_path(model_name) or MODEL_PATH
+            if path and os.path.exists(path):
+                try:
+                    sessions[model_name] = ort.InferenceSession(path)
+                except Exception:
+                    logging.getLogger(__name__).exception("Failed to load model %s", path)
+                    sessions[model_name] = None
+            else:
+                sessions[model_name] = None
+    return sessions[model_name]
 
 
-def classify(text: str) -> str:
-    load_session()
+def classify(text: str, model_name: str) -> str:
+    session = load_session(model_name)
     if session is None:
         # Fallback simple rule when ONNX model is unavailable
         return "positive" if "good" in text.lower() else "negative"
@@ -72,7 +97,7 @@ async def chat(request: Request):
                     text += part.get("text", "")
         else:
             text = str(content)
-    result = classify(text)
+    result = classify(text, req.model or (MODEL_PATH or ""))
     return {
         "id": "cmpl-001",
         "object": "chat.completion",

--- a/apps/onnx_chat/requirements.txt
+++ b/apps/onnx_chat/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 onnxruntime
 pydantic
+huggingface_hub

--- a/apps/shared/hf_utils.py
+++ b/apps/shared/hf_utils.py
@@ -1,0 +1,27 @@
+import os
+import logging
+import shutil
+from typing import Optional
+
+try:
+    from huggingface_hub import hf_hub_download
+except Exception:  # pragma: no cover - optional dependency
+    hf_hub_download = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def download_model(repo_id: str, filename: str, cache_subdir: str) -> str:
+    """Download a file from Hugging Face with local caching."""
+    if hf_hub_download is None:
+        raise RuntimeError("huggingface_hub not available")
+
+    cache_dir = os.path.expanduser(cache_subdir)
+    local_path = os.path.join(cache_dir, filename)
+    os.makedirs(os.path.dirname(local_path), exist_ok=True)
+
+    if not os.path.exists(local_path):
+        downloaded_path = hf_hub_download(repo_id=repo_id, filename=filename)
+        shutil.copy(downloaded_path, local_path)
+        logger.info(f"Downloaded {repo_id}/{filename} to {local_path}")
+    return local_path

--- a/integration_tests/test_server_api.py
+++ b/integration_tests/test_server_api.py
@@ -19,7 +19,7 @@ def _client(monkeypatch):
     if TestClient is None:
         pytest.skip("fastapi not available")
     # ensure classify returns predictable output
-    monkeypatch.setattr(onnx_server, "classify", lambda text: "positive")
+    monkeypatch.setattr(onnx_server, "classify", lambda text, model=None: "positive")
     return TestClient(app)
 
 

--- a/tests/test_onnx_dynamic.py
+++ b/tests/test_onnx_dynamic.py
@@ -1,0 +1,30 @@
+import os
+import types
+
+import apps.onnx_chat.main as chat
+
+
+def test_load_session_download(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_download(repo_id, filename, cache_dir):
+        called['args'] = (repo_id, filename, cache_dir)
+        path = tmp_path / filename
+        path.write_text('x')
+        return str(path)
+
+    class FakeORT:
+        def InferenceSession(self, path):
+            called['path'] = path
+            return f'session:{path}'
+
+    monkeypatch.setattr(chat, 'download_model', fake_download)
+    monkeypatch.setattr(chat, 'ort', FakeORT())
+    chat.sessions.clear()
+
+    sess = chat.load_session('repo/model:onx.onnx')
+    assert called['args'][0] == 'repo/model'
+    assert called['args'][1] == 'onx.onnx'
+    assert 'onnx_chat' in called['args'][2]
+    assert sess == f'session:{tmp_path/"onx.onnx"}'
+


### PR DESCRIPTION
## Summary
- add shared `download_model` helper for Hugging Face downloads
- use helper in face API
- update chat server to load ONNX models from Hugging Face on demand
- document dynamic model usage and add required dependency
- adjust integration tests and add new unit test for dynamic loading

## Testing
- `pytest -q`
- `pytest integration_tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68787ab27a088331a06c568b4b937ea5