### PR TITLE
Enable dynamic HF models for chat server

### DIFF
--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -70,18 +70,16 @@ class ModelLoader:
         return providers
 
     def _download_model(self, model_id: str, filename: str, cache_dir: str) -> str:
-        local_path = os.path.join(cache_dir, filename)
-        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        """Wrapper around the shared Hugging Face downloader."""
+        from apps.hf_cache import download_file
 
-        if not os.path.exists(local_path):
-            try:
-                downloaded_path = hf_hub_download(repo_id=model_id, filename=filename)
-                shutil.copy(downloaded_path, local_path)
-                logger.info(f"Downloaded {model_id}/{filename} to {local_path}")
-            except Exception as e:
-                logger.exception(f"Failed to download model {model_id}/{filename}; aborting startup")
-                raise
-        return local_path
+        try:
+            return download_file(model_id, filename, cache_dir)
+        except Exception:
+            logger.exception(
+                f"Failed to download model {model_id}/{filename}; aborting startup"
+            )
+            raise
 
     def load_detector(self):
         if self._detector is None:

--- a/apps/hf_cache.py
+++ b/apps/hf_cache.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import os
+import shutil
+from typing import Optional
+
+try:
+    from huggingface_hub import hf_hub_download, snapshot_download
+except Exception:  # pragma: no cover - optional
+    hf_hub_download = None  # type: ignore
+    snapshot_download = None  # type: ignore
+
+
+def download_file(repo_id: str, filename: str, cache_dir: str) -> str:
+    """Download a file from Hugging Face with caching."""
+    if hf_hub_download is None:
+        raise RuntimeError("huggingface_hub is required")
+    cache_dir = os.path.expanduser(cache_dir)
+    local_path = os.path.join(cache_dir, filename)
+    os.makedirs(os.path.dirname(local_path), exist_ok=True)
+    if not os.path.exists(local_path):
+        downloaded_path = hf_hub_download(repo_id=repo_id, filename=filename)
+        shutil.copy(downloaded_path, local_path)
+    return local_path
+
+
+def download_repo(repo_id: str, cache_dir: str) -> str:
+    """Download an entire repository snapshot if not cached."""
+    if snapshot_download is None:
+        raise RuntimeError("huggingface_hub is required")
+    cache_dir = os.path.expanduser(cache_dir)
+    if not os.path.exists(cache_dir):
+        snapshot_download(repo_id=repo_id, local_dir=cache_dir, local_dir_use_symlinks=False)
+    return cache_dir

--- a/apps/onnx_chat/config.py
+++ b/apps/onnx_chat/config.py
@@ -8,6 +8,7 @@ class Config:
     model_path: str | None
     port: int
     log_level: str
+    hf_cache_dir: str
     host: str = "0.0.0.0"
 
 
@@ -18,7 +19,8 @@ def load_config() -> Config:
         raise FileNotFoundError(f"ONNX model path '{model_path}' does not exist")
     port = int(os.getenv("COMFYAI_ONNX_PORT", "8000"))
     log_level = os.getenv("ONNX_LOG_LEVEL", "info")
-    return Config(model_path=model_path, port=port, log_level=log_level)
+    cache_dir = os.getenv("HF_MODEL_CACHE", os.path.expanduser("~/.cache/onnx_chat"))
+    return Config(model_path=model_path, port=port, log_level=log_level, hf_cache_dir=cache_dir)
 
 
 def setup_logging() -> None:

--- a/apps/onnx_chat/main.py
+++ b/apps/onnx_chat/main.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import os
 from typing import List, Dict, Any
+
+from apps.hf_cache import download_repo
 import argparse
 import logging
 
@@ -10,6 +12,13 @@ from pydantic import BaseModel, ValidationError
 
 from .config import load_config, setup_logging
 
+try:  # optional heavy deps
+    from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+except Exception:  # pragma: no cover - optional dependency
+    AutoModelForCausalLM = None  # type: ignore
+    AutoTokenizer = None  # type: ignore
+    pipeline = None  # type: ignore
+
 try:
     import onnxruntime as ort
 except Exception:  # pragma: no cover - optional dependency
@@ -18,7 +27,23 @@ except Exception:  # pragma: no cover - optional dependency
 setup_logging()
 config = load_config()
 
+HF_CACHE_DIR = config.hf_cache_dir
+PIPELINES: dict[str, Any] = {}
+
 app = FastAPI()
+
+
+def load_pipeline(model_id: str):
+    """Return a cached text generation pipeline for the given model."""
+    if pipeline is None or AutoTokenizer is None or AutoModelForCausalLM is None:
+        return None
+    if model_id not in PIPELINES:
+        cache_dir = os.path.join(HF_CACHE_DIR, model_id.replace("/", "_"))
+        local_repo = download_repo(model_id, cache_dir)
+        tokenizer = AutoTokenizer.from_pretrained(local_repo)
+        model = AutoModelForCausalLM.from_pretrained(local_repo)
+        PIPELINES[model_id] = pipeline("text-generation", model=model, tokenizer=tokenizer)
+    return PIPELINES[model_id]
 
 class ChatRequest(BaseModel):
     model: str
@@ -29,7 +54,11 @@ class ChatRequest(BaseModel):
 @app.get("/health")
 async def health_check():
     model_name = os.path.basename(MODEL_PATH) if MODEL_PATH else "none"
-    return {"status": "ok", "model": model_name}
+    return {
+        "status": "ok",
+        "model": model_name,
+        "loaded_pipelines": list(PIPELINES.keys()),
+    }
 
 session = None
 MODEL_PATH = config.model_path
@@ -72,7 +101,16 @@ async def chat(request: Request):
                     text += part.get("text", "")
         else:
             text = str(content)
-    result = classify(text)
+    pipe = load_pipeline(req.model)
+    if pipe is not None:
+        try:
+            out = pipe(text, max_new_tokens=req.max_tokens or 16)
+            result = out[0].get("generated_text", "")
+        except Exception:
+            logging.getLogger(__name__).exception("Pipeline inference failed; falling back")
+            result = classify(text)
+    else:
+        result = classify(text)
     return {
         "id": "cmpl-001",
         "object": "chat.completion",

--- a/apps/onnx_chat/requirements.txt
+++ b/apps/onnx_chat/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 onnxruntime
 pydantic
+transformers
+huggingface_hub

--- a/integration_tests/test_server_api.py
+++ b/integration_tests/test_server_api.py
@@ -20,6 +20,7 @@ def _client(monkeypatch):
         pytest.skip("fastapi not available")
     # ensure classify returns predictable output
     monkeypatch.setattr(onnx_server, "classify", lambda text: "positive")
+    monkeypatch.setattr(onnx_server, "load_pipeline", lambda m: None)
     return TestClient(app)
 
 

--- a/tests/test_onnx_chat.py
+++ b/tests/test_onnx_chat.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+
+def _load_app(monkeypatch):
+    sys.modules.pop('apps.onnx_chat.main', None)
+    import apps.onnx_chat.main as chat_main
+    importlib.reload(chat_main)
+    monkeypatch.setattr(chat_main, 'download_repo', lambda r, c: c)
+    monkeypatch.setattr(chat_main, 'AutoTokenizer', SimpleNamespace(from_pretrained=lambda p: 'tok'))
+    monkeypatch.setattr(chat_main, 'AutoModelForCausalLM', SimpleNamespace(from_pretrained=lambda p: 'model'))
+    calls = {}
+
+    class FakePipe:
+        def __call__(self, text, max_new_tokens=16):
+            calls['text'] = text
+            calls['tokens'] = max_new_tokens
+            return [{'generated_text': text[::-1]}]
+
+    def fake_pipeline(task, model=None, tokenizer=None):
+        calls['task'] = task
+        return FakePipe()
+
+    monkeypatch.setattr(chat_main, 'pipeline', fake_pipeline)
+    return TestClient(chat_main.app), calls
+
+
+def test_dynamic_model_loading(monkeypatch):
+    client, calls = _load_app(monkeypatch)
+    resp = client.post(
+        '/v1/chat/completions',
+        json={'model': 'hf/test', 'messages': [{'role': 'user', 'content': 'hi'}], 'max_tokens': 5}
+    )
+    assert resp.status_code == 200
+    assert resp.json()['choices'][0]['message']['content'] == 'ih'
+    assert calls['task'] == 'text-generation'
+    assert calls['text'] == 'hi'
+    assert calls['tokens'] == 5


### PR DESCRIPTION
## Summary
- share Hugging Face download utilities across apps
- add dynamic model loading via transformers in chat server
- cache HF repos under `HF_MODEL_CACHE`
- update integration tests and add unit test for chat server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68787ab27a088331a06c568b4b937ea5