### PR TITLE
Dynamic huggingface loading for chat server

### DIFF
--- a/apps/face_api/main.py
+++ b/apps/face_api/main.py
@@ -11,10 +11,6 @@ try:
     import onnxruntime as ort
 except Exception:  # pragma: no cover - optional dependency
     ort = None
-try:
-    from huggingface_hub import hf_hub_download
-except Exception:  # pragma: no cover - optional dependency
-    hf_hub_download = None
 import shutil
 
 # Requires: pip install dghs-imgutils
@@ -70,18 +66,13 @@ class ModelLoader:
         return providers
 
     def _download_model(self, model_id: str, filename: str, cache_dir: str) -> str:
-        local_path = os.path.join(cache_dir, filename)
-        os.makedirs(os.path.dirname(local_path), exist_ok=True)
-
-        if not os.path.exists(local_path):
-            try:
-                downloaded_path = hf_hub_download(repo_id=model_id, filename=filename)
-                shutil.copy(downloaded_path, local_path)
-                logger.info(f"Downloaded {model_id}/{filename} to {local_path}")
-            except Exception as e:
-                logger.exception(f"Failed to download model {model_id}/{filename}; aborting startup")
-                raise
-        return local_path
+        """Download a model file using the shared Hugging Face util."""
+        try:
+            from apps.hf_utils import download_file
+            return download_file(model_id, filename, cache_dir)
+        except Exception:
+            logger.exception(f"Failed to download model {model_id}/{filename}; aborting startup")
+            raise
 
     def load_detector(self):
         if self._detector is None:

--- a/apps/hf_utils.py
+++ b/apps/hf_utils.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+import logging
+from typing import Optional
+
+try:
+    from huggingface_hub import hf_hub_download, snapshot_download
+except Exception:  # pragma: no cover - optional dependency
+    hf_hub_download = None
+    snapshot_download = None
+
+logger = logging.getLogger(__name__)
+
+
+def download_file(repo_id: str, filename: str, cache_dir: str) -> str:
+    """Download a single file from Hugging Face with caching."""
+    if hf_hub_download is None:
+        raise RuntimeError("huggingface_hub is not available")
+    local_path = os.path.join(cache_dir, filename)
+    os.makedirs(os.path.dirname(local_path), exist_ok=True)
+    if not os.path.exists(local_path):
+        path = hf_hub_download(repo_id=repo_id, filename=filename)
+        shutil.copy(path, local_path)
+        logger.info(f"Downloaded {repo_id}/{filename} to {local_path}")
+    return local_path
+
+
+def download_repo(repo_id: str, cache_dir: str) -> str:
+    """Download an entire repository snapshot into ``cache_dir``."""
+    if snapshot_download is None:
+        raise RuntimeError("huggingface_hub is not available")
+    local_dir = os.path.join(cache_dir, repo_id.replace("/", "_"))
+    if not os.path.exists(local_dir):
+        temp_dir = snapshot_download(repo_id=repo_id)
+        shutil.copytree(temp_dir, local_dir)
+        logger.info(f"Downloaded repo {repo_id} to {local_dir}")
+    return local_dir

--- a/apps/onnx_chat/main.py
+++ b/apps/onnx_chat/main.py
@@ -4,6 +4,12 @@ from typing import List, Dict, Any
 import argparse
 import logging
 
+try:
+    from transformers import pipeline
+except Exception:  # pragma: no cover - optional dependency
+    pipeline = None
+from apps.hf_utils import download_repo
+
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError
@@ -33,6 +39,8 @@ async def health_check():
 
 session = None
 MODEL_PATH = config.model_path
+_hf_pipelines: dict[str, Any] = {}
+HF_CACHE = os.path.expanduser("~/.cache/onnx_chat/models")
 
 
 def load_session():
@@ -41,14 +49,28 @@ def load_session():
         session = ort.InferenceSession(MODEL_PATH)
 
 
-def classify(text: str) -> str:
+def get_pipeline(model_name: str):
+    if pipeline is None:
+        raise RuntimeError("transformers is not available")
+    if model_name not in _hf_pipelines:
+        model_dir = download_repo(model_name, HF_CACHE)
+        _hf_pipelines[model_name] = pipeline("text-generation", model=model_dir, tokenizer=model_dir)
+    return _hf_pipelines[model_name]
+
+
+def classify(text: str, model_name: str) -> str:
+    """Classify or generate text using ONNX or Hugging Face models."""
     load_session()
-    if session is None:
-        # Fallback simple rule when ONNX model is unavailable
+    if session is not None:
+        inputs = {session.get_inputs()[0].name: [[ord(c) for c in text]]}
+        outputs = session.run(None, inputs)[0]
+        return str(outputs[0])
+    try:
+        pipe = get_pipeline(model_name)
+        result = pipe(text, max_new_tokens=20)
+        return result[0]["generated_text"]
+    except Exception:
         return "positive" if "good" in text.lower() else "negative"
-    inputs = {session.get_inputs()[0].name: [[ord(c) for c in text]]}
-    outputs = session.run(None, inputs)[0]
-    return str(outputs[0])
 
 
 @app.post("/v1/chat/completions")
@@ -72,7 +94,7 @@ async def chat(request: Request):
                     text += part.get("text", "")
         else:
             text = str(content)
-    result = classify(text)
+    result = classify(text, req.model)
     return {
         "id": "cmpl-001",
         "object": "chat.completion",

--- a/apps/onnx_chat/requirements.txt
+++ b/apps/onnx_chat/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 onnxruntime
 pydantic
+transformers
+huggingface_hub

--- a/integration_tests/test_server_api.py
+++ b/integration_tests/test_server_api.py
@@ -19,7 +19,7 @@ def _client(monkeypatch):
     if TestClient is None:
         pytest.skip("fastapi not available")
     # ensure classify returns predictable output
-    monkeypatch.setattr(onnx_server, "classify", lambda text: "positive")
+    monkeypatch.setattr(onnx_server, "classify", lambda text, model: "positive")
     return TestClient(app)
 
 
@@ -64,3 +64,21 @@ def test_chat_endpoint_with_two_images(monkeypatch):
     resp = client.post("/v1/chat/completions", json={"model": "test", "messages": [msg]})
     assert resp.status_code == 200
     assert resp.json()["choices"][0]["message"]["content"] == "positive"
+
+
+def test_model_name_forwarded(monkeypatch):
+    if TestClient is None:
+        pytest.skip("fastapi not available")
+    called = {}
+
+    def fake_classify(text, model):
+        called["model"] = model
+        return "ok"
+
+    monkeypatch.setattr(onnx_server, "classify", fake_classify)
+    client = TestClient(app)
+    client.post(
+        "/v1/chat/completions",
+        json={"model": "hf-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert called["model"] == "hf-model"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
 -r apps/face_api/requirements.txt
+-r apps/onnx_chat/requirements.txt
 pytest>=7.0
 httpx

--- a/tests/test_hf_utils.py
+++ b/tests/test_hf_utils.py
@@ -1,0 +1,34 @@
+import os
+from apps import hf_utils
+
+
+def test_download_file(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_download(repo_id, filename):
+        called['args'] = (repo_id, filename)
+        p = tmp_path / "src"
+        p.write_text("x")
+        return str(p)
+
+    monkeypatch.setattr(hf_utils, "hf_hub_download", fake_download)
+    dest = hf_utils.download_file("repo", "file.txt", tmp_path)
+    assert called['args'] == ("repo", "file.txt")
+    assert os.path.exists(dest)
+
+
+def test_download_repo(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_snapshot(repo_id):
+        called['repo'] = repo_id
+        src = tmp_path / "snap"
+        src.mkdir()
+        (src / "a.txt").write_text("x")
+        return str(src)
+
+    monkeypatch.setattr(hf_utils, "snapshot_download", fake_snapshot)
+    path = hf_utils.download_repo("repo", tmp_path)
+    assert called['repo'] == "repo"
+    assert os.path.isdir(path)
+    assert os.path.exists(os.path.join(path, "a.txt"))


### PR DESCRIPTION
## Summary
- add shared HF download utilities
- update face API to use the shared download function
- load HF text-generation models in chat server
- adjust integration test to check model forwarding
- require transformers in onnx chat and update dev requirements
- test the new helper utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68787ab27a088331a06c568b4b937ea5