### PR TITLE
Add manage cache API and master entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim AS builder
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --prefix=/install --no-cache-dir -r requirements.txt
+COPY . .
+RUN pip install --prefix=/install --no-cache-dir .
+
+FROM python:3.10-slim
+WORKDIR /app
+COPY --from=builder /install /usr/local
+COPY . .
+CMD ["uvicorn", "comfyai.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/chat_server/router.py
+++ b/apps/chat_server/router.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+from apps.onnx_chat.main import app as chat_app
+
+router = APIRouter()
+router.include_router(chat_app.router)

--- a/apps/face_server/router.py
+++ b/apps/face_server/router.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+from apps.face_api.main import app as face_app
+
+router = APIRouter()
+router.include_router(face_app.router)

--- a/apps/manage_api/router.py
+++ b/apps/manage_api/router.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from nodes.manage_cache import (
+    list_repo_files,
+    list_cached_entries,
+    download_file,
+    delete_cached_file,
+)
+
+router = APIRouter(prefix="/api/manage", tags=["manage"])
+
+
+class DownloadRequest(BaseModel):
+    repo: str
+    path: str
+
+
+class DeleteRequest(BaseModel):
+    repo: str
+    path: str
+
+
+@router.get("/repos/{repo_id}/files")
+async def get_remote_files(repo_id: str):
+    try:
+        files = list_repo_files(repo_id)
+        return {"files": files}
+    except Exception as e:  # pragma: no cover - error case
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/cache")
+async def get_cache():
+    entries = list_cached_entries()
+    return {"cache": entries}
+
+
+@router.post("/cache/download", status_code=202)
+async def post_download(req: DownloadRequest):
+    try:
+        download_file(repo_id=req.repo, file_path=req.path)
+    except Exception as e:  # pragma: no cover - error case
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete("/cache", status_code=200)
+async def delete_cache(req: DeleteRequest):
+    try:
+        delete_cached_file(repo_id=req.repo, file_path=req.path)
+    except Exception as e:  # pragma: no cover - error case
+        raise HTTPException(status_code=500, detail=str(e))

--- a/build-server.sh
+++ b/build-server.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+uvicorn comfyai.main:app --host 0.0.0.0 --port 8000

--- a/comfyai/main.py
+++ b/comfyai/main.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+from apps.chat_server.router import router as chat_router
+from apps.face_server.router import router as face_router
+from apps.manage_api.router import router as manage_router
+from common.logging import setup_logging
+
+setup_logging()
+app = FastAPI(title="ComfyAI Master API")
+
+app.include_router(chat_router, prefix="/chat", tags=["chat"])
+app.include_router(face_router, prefix="/face", tags=["face"])
+app.include_router(manage_router, prefix="/manage", tags=["manage"])

--- a/common/logging.py
+++ b/common/logging.py
@@ -1,0 +1,8 @@
+import logging
+import os
+
+
+def setup_logging() -> None:
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(level=level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")

--- a/nodes/manage_cache.py
+++ b/nodes/manage_cache.py
@@ -1,0 +1,72 @@
+import os
+from typing import List, Dict
+
+try:
+    from huggingface_hub import HfApi, hf_hub_download, scan_cache_dir
+except Exception:  # pragma: no cover - optional dependency
+    HfApi = None
+    hf_hub_download = None
+    scan_cache_dir = None
+
+
+def list_repo_files(repo_id: str) -> List[Dict[str, int]]:
+    """Return file listing for a repo."""
+    if HfApi is None:
+        raise RuntimeError("huggingface_hub not available")
+    info = HfApi().repo_info(repo_id)
+    return [
+        {"path": s.rfilename, "size": getattr(s, "size", 0) or 0}
+        for s in getattr(info, "siblings", [])
+    ]
+
+
+def list_cached_entries() -> List[Dict[str, object]]:
+    """Return details about cached files."""
+    if scan_cache_dir is None:
+        raise RuntimeError("huggingface_hub not available")
+    scan = scan_cache_dir()
+    entries: List[Dict[str, object]] = []
+    for repo in scan.repos:
+        repo_id = repo.repo_id
+        for rev in repo.revisions:
+            for f in rev.files:
+                entries.append(
+                    {
+                        "repo": repo_id,
+                        "path": f.file_name,
+                        "size": f.size_on_disk,
+                        "last_used": f.blob_last_accessed,
+                    }
+                )
+    return entries
+
+
+def download_file(repo_id: str, file_path: str) -> str:
+    """Download a file into the local Hugging Face cache."""
+    if hf_hub_download is None:
+        raise RuntimeError("huggingface_hub not available")
+    return hf_hub_download(repo_id=repo_id, filename=file_path)
+
+
+def delete_cached_file(repo_id: str, file_path: str) -> None:
+    """Remove a cached file and its blob if present."""
+    if hf_hub_download is None:
+        raise RuntimeError("huggingface_hub not available")
+    path = hf_hub_download(repo_id=repo_id, filename=file_path, local_files_only=True)
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+    if scan_cache_dir is None:
+        return
+    scan = scan_cache_dir()
+    for repo in scan.repos:
+        if repo.repo_id != repo_id:
+            continue
+        for rev in repo.revisions:
+            for f in rev.files:
+                if f.file_name == file_path:
+                    try:
+                        os.remove(f.blob_path)
+                    except Exception:
+                        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["nodes*", "apps*"]
+include = ["nodes*", "apps*", "comfyai*", "common*"]
 
 [project.optional-dependencies]
 onnx = [

--- a/tests/test_manage_api.py
+++ b/tests/test_manage_api.py
@@ -1,0 +1,54 @@
+import os, sys
+sys.modules.pop("fastapi", None)
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("DETECTOR_MODEL", "fake")
+os.environ.setdefault("DETECTOR_FILE", "model.onnx")
+os.environ.setdefault("EMBEDDER_MODEL_PATH", "fake")
+os.environ.setdefault("EMBEDDER_FILE", "model.onnx")
+
+from comfyai.main import app
+import apps.manage_api.router as manage_router
+
+client = TestClient(app)
+
+
+def test_get_remote_files(monkeypatch):
+    monkeypatch.setattr(manage_router, "list_repo_files", lambda repo: [{"path": "f", "size": 1}])
+    resp = client.get("/manage/api/manage/repos/test/files")
+    assert resp.status_code == 200
+    assert resp.json() == {"files": [{"path": "f", "size": 1}]}
+
+
+def test_get_cache(monkeypatch):
+    monkeypatch.setattr(manage_router, "list_cached_entries", lambda: [{"repo": "r", "path": "p", "size": 1, "last_used": 0.0}])
+    resp = client.get("/manage/api/manage/cache")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["cache"][0]["repo"] == "r"
+
+
+def test_post_download(monkeypatch):
+    called = {}
+
+    def fake_dl(repo_id, file_path):
+        called["repo"] = repo_id
+        called["path"] = file_path
+
+    monkeypatch.setattr(manage_router, "download_file", fake_dl)
+    resp = client.post("/manage/api/manage/cache/download", json={"repo": "r", "path": "x"})
+    assert resp.status_code == 202
+    assert called == {"repo": "r", "path": "x"}
+
+
+def test_delete_cache(monkeypatch):
+    called = {}
+
+    def fake_del(repo_id, file_path):
+        called["repo"] = repo_id
+        called["path"] = file_path
+
+    monkeypatch.setattr(manage_router, "delete_cached_file", fake_del)
+    resp = client.request("DELETE", "/manage/api/manage/cache", json={"repo": "r", "path": "y"})
+    assert resp.status_code == 200
+    assert called == {"repo": "r", "path": "y"}


### PR DESCRIPTION
## Summary
- implement manage cache router for listing and controlling HF cache
- add unified FastAPI entrypoint `comfyai.main`
- create lightweight logging helper and routers wrapping existing apps
- provide Dockerfile and CLI script for starting server
- add manage cache API tests and package config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687885bafb30833198c98e6ac9b5541a